### PR TITLE
Atari 8 bit port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ LIBBIOS_OBJS = \
 	$(OBJDIR)/src/bios/relocate.o \
 	$(OBJDIR)/src/bios/petscii.o \
 
-all: c64.d64 bbcmicro.ssd x16.zip
+all: c64.d64 bbcmicro.ssd x16.zip atari.atr
 
 $(OBJDIR)/multilink: tools/multilink.cc
 	@mkdir -p $(dir $@)
@@ -61,11 +61,15 @@ $(OBJDIR)/ccp.sys: $(OBJDIR)/src/ccp.o $(OBJDIR)/libcpm.a
 $(OBJDIR)/%.exe: $(OBJDIR)/src/bios/%.o $(OBJDIR)/libbios.a scripts/%.ld
 	@mkdir -p $(dir $@)
 	ld.lld -Map $(patsubst %.exe,%.map,$@) -T scripts/$*.ld -o $@ $< $(OBJDIR)/libbios.a
-	
+
+atari.atr: $(OBJDIR)/atari.exe $(OBJDIR)/bdos.img Makefile
+	echo "TODO"
+
 $(OBJDIR)/bbcmicrofs.img: $(APPS) $(OBJDIR)/ccp.sys
 	mkfs.cpm -f bbc192 $@
 	cpmcp -f bbc192 $@ $(OBJDIR)/ccp.sys $(APPS) 0:
 	cpmchattr -f bbc192 $@ s 0:ccp.sys
+
 
 bbcmicro.ssd: $(OBJDIR)/bbcmicro.exe $(OBJDIR)/bdos.img Makefile $(OBJDIR)/bbcmicrofs.img $(OBJDIR)/mkdfs
 	$(OBJDIR)/mkdfs -O $@ \
@@ -111,7 +115,7 @@ x16.zip: $(OBJDIR)/x16.exe $(OBJDIR)/bdos.img $(OBJDIR)/generic-1m-cpmfs.img
 	printf "@ generic-1m-cpmfs.img\n@=CPMFS\n" | zipnote -w $@
 
 clean:
-	rm -rf $(OBJDIR) c64.d64 bbcmicro.ssd x16.zip
+	rm -rf $(OBJDIR) c64.d64 bbcmicro.ssd x16.zip atari.atr
 
 .DELETE_ON_ERROR:
 .SECONDARY:

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ $(OBJDIR)/mkdfs: tools/mkdfs.c
 	@mkdir -p $(dir $@)
 	$(CXX) -Os -g -o $@ $<
 
+$(OBJDIR)/mkatr: tools/mkatr.c
+	@mkdir -p $(dir $@)
+	$(CXX) -Os -g -o $@ $<
+
 $(OBJDIR)/%.o: %.S include/zif.inc include/mos.inc include/cpm65.inc
 	@mkdir -p $(dir $@)
 	mos-cpm65-clang $(CFLAGS65) -c -o $@ $< -I include
@@ -62,7 +66,7 @@ $(OBJDIR)/%.exe: $(OBJDIR)/src/bios/%.o $(OBJDIR)/libbios.a scripts/%.ld
 	@mkdir -p $(dir $@)
 	ld.lld -Map $(patsubst %.exe,%.map,$@) -T scripts/$*.ld -o $@ $< $(OBJDIR)/libbios.a
 
-atari.atr: $(OBJDIR)/atari.exe $(OBJDIR)/bdos.img Makefile
+atari.atr: $(OBJDIR)/atari.exe $(OBJDIR)/bdos.img Makefile $(OBJDIR)/mkatr
 	echo "TODO"
 
 $(OBJDIR)/bbcmicrofs.img: $(APPS) $(OBJDIR)/ccp.sys

--- a/scripts/atari.ld
+++ b/scripts/atari.ld
@@ -1,0 +1,40 @@
+
+MEMORY {
+    zp : ORIGIN = 0x80, LENGTH = 0x80
+    ram (rw) : ORIGIN = 0x600, LENGTH = 0x400
+}
+
+SECTIONS {
+	.zp : {
+		*(.zp .zp.*)
+		__USERZEROPAGE_START__ = .;
+		__USERZEROPAGE_END__ = 0x100;
+	} >zp
+
+	.text : { *(.text .text.*) } >ram
+	.data : {
+          *(.data .data.* .rodata .rodata.*)
+          __data_end = .;
+    } > ram
+	.noinit (NOLOAD) : { *(.noinit .noinit.*) } >ram
+}
+
+OUTPUT_FORMAT {
+    /* XEX magic number. */
+    SHORT(0xffff)
+    /* First byte of Run vector. */
+    SHORT(0x02e0)
+    /* Last byte of Run vector. */
+    SHORT(0x02e1)
+    /* Segment to be loaded to Run vector. */
+    SHORT(_start)
+    /* Address where first byte of main segment should be loaded. */
+    SHORT(0x2000)
+    /* Address of last byte of main segment.
+       -- is a hack to force the early evalutation of __data_end; otherwise the
+       -1 offset may be interpreted as requesting the end of the containing
+       section. */
+    SHORT(--__data_end - 1)
+
+    TRIM(ram)
+}

--- a/scripts/atari.ld
+++ b/scripts/atari.ld
@@ -11,7 +11,10 @@ SECTIONS {
 		__USERZEROPAGE_END__ = 0x100;
 	} >zp
 
-	.text : { *(.text .text.*) } >ram
+	.text : {
+          __text_start = .;
+          *(.text .text.*)
+    } >ram
 	.data : {
           *(.data .data.* .rodata .rodata.*)
           __data_end = .;
@@ -29,7 +32,7 @@ OUTPUT_FORMAT {
     /* Segment to be loaded to Run vector. */
     SHORT(_start)
     /* Address where first byte of main segment should be loaded. */
-    SHORT(0x2000)
+    SHORT(0x600)
     /* Address of last byte of main segment.
        -- is a hack to force the early evalutation of __data_end; otherwise the
        -1 offset may be interpreted as requesting the end of the containing

--- a/src/bios/atari.S
+++ b/src/bios/atari.S
@@ -4,7 +4,6 @@
 
 #include "zif.inc"
 #include "cpm65.inc"
-#include <atari.inc>
 
 EOL = $9B                       ; ATASCII EOL character
 
@@ -12,11 +11,18 @@ EOL = $9B                       ; ATASCII EOL character
 EDITRV = $E400                  ; Editor Vector
 SCRENV = $E410                  ; Screen Vector
 KEYBDV = $E420                  ; Keyboard Vector
+CIOV   = $E456                  ; CIO Vector
+
+RAMTOP = $026A
+RAMSIZ = $02E4
 MEMTOP = $02E5                  ; Top of available memory
 MEMLO  = $02E7                  ; Bottom of available memory
 COLOR1 = $2C5                   ; Foreground color (luminance)
 COLOR2 = $2C6                   ; Foreground color (hue)
 COLOR4 = $2C8                   ; Background color
+
+PORTB  = $0301
+BASICF = $03F8
 
 ICHID  = $0340                  ; Hander identifier
 ICDNO  = ICHID + 1              ; Device number
@@ -29,6 +35,7 @@ ICPTH  = ICHID + 7              ; Put address (high byte)
 ICBLL  = ICHID + 8              ; Buffer length (low byte)
 ICBLH  = ICHID + 9              ; Buffer length (high byte)
 ICAX1  = ICHID + 10             ; Auxiliary information
+ICAX2  = ICHID + 11             ; Auxiliary information
 
 ; IOCB Offsets
 IOCB0  = $00
@@ -61,27 +68,49 @@ ZEROPAGE
 ptr:    .word 0
 
 zproc _start
+    ldx #$ff
+    txs
+
     ; Set screen color to white on black
     lda #0
     sta COLOR4                  ; Black background
     sta COLOR2                  ; Grey hue
     lda #$0F                    ; Highest luminance
+    sta COLOR1
 
     ; Get an IOCB for the screen editor device
+    ldx #0
     jsr get_free_iocb
     stx editor_iocb
 
     ; Load "E:" as the device name
     lda #<editor_device
     sta ICBAL,x
-    lda #>editor_decice
+    lda #>editor_device
     sta ICBAH,x
 
+    lda #CIO_OPEN
+    sta ICCOM,x
+
+    lda #CIO_WRITE
+    sta ICAX1,x
+
+    lda #0
+    sta ICAX2,x
+
+    sta ICBLH,x
+    sta ICBLL,x
+
+    jsr CIOV
+
+    lda #>editor_device
+    ldy #<editor_device
+
+    jsr print
 
 
 loop:
     jmp loop
-    rts
 zendproc
 
 zproc init_system
@@ -95,10 +124,10 @@ zproc get_free_iocb
 
     zloop
         tya                     ; Calculate IOCB offset
-        rol                     ; (y * 16)
-        rol
-        rol
-        rol
+        asl                     ; (y * 16)
+        asl
+        asl
+        asl
         tax
         lda ICHID,x             ; Load the IOCB handler
 
@@ -116,12 +145,49 @@ zproc get_free_iocb
     zendloop
 zendproc
 
-editor_device:
-    .byte $45, $3A, EOL         ; ATASCII for 'E:\n'
+zproc print
+    ldx editor_iocb
+
+    sta ICBAH,x
+    tya
+    sta ICBAL,x
+
+    lda #CIO_PRINT
+    sta ICCOM,x
+
+    lda #0
+    sta ICBLL,x
+    lda #$ff
+    sta ICBLH,x
+
+    jsr CIOV
+    rts
+zendproc
+
+zproc disable_basic
+    lda #$c0
+    cmp RAMTOP
+    zif_ne
+        sta RAMTOP              ; Set RAMTOP to the end of BASIC
+        sta RAMSIZ
+
+        lda PORTB               ; Disable BASIC bit
+        ora #$02
+        sta PORTB
+
+        lda #$01
+
+    
+    zendif
+
+zendproc
 
     .data
 zp_base:    .byte __USERZEROPAGE_START__
 zp_end:     .byte __USERZEROPAGE_END__
+
+editor_device:
+    .byte $45, $3A, EOL         ; ATASCII for 'E:\n'
 
 NOINIT
 

--- a/src/bios/atari.S
+++ b/src/bios/atari.S
@@ -1,0 +1,128 @@
+; CP/M-65 Copyright © 2022 David Given
+; This file is licensed under the terms of the 2-clause BSD license. Please
+; see the COPYING file in the root project directory for the full text.
+
+#include "zif.inc"
+#include "cpm65.inc"
+#include <atari.inc>
+
+EOL = $9B                       ; ATASCII EOL character
+
+;   VECTOR TABLE
+EDITRV = $E400                  ; Editor Vector
+SCRENV = $E410                  ; Screen Vector
+KEYBDV = $E420                  ; Keyboard Vector
+MEMTOP = $02E5                  ; Top of available memory
+MEMLO  = $02E7                  ; Bottom of available memory
+COLOR1 = $2C5                   ; Foreground color (luminance)
+COLOR2 = $2C6                   ; Foreground color (hue)
+COLOR4 = $2C8                   ; Background color
+
+ICHID  = $0340                  ; Hander identifier
+ICDNO  = ICHID + 1              ; Device number
+ICCOM  = ICHID + 2              ; Command
+ICSTA  = ICHID + 3              ; Status
+ICBAL  = ICHID + 4              ; Buffer address (low byte)
+ICBAH  = ICHID + 5              ; Buffer address (high byte)
+ICPTL  = ICHID + 6              ; Put address (low byte)
+ICPTH  = ICHID + 7              ; Put address (high byte)
+ICBLL  = ICHID + 8              ; Buffer length (low byte)
+ICBLH  = ICHID + 9              ; Buffer length (high byte)
+ICAX1  = ICHID + 10             ; Auxiliary information
+
+; IOCB Offsets
+IOCB0  = $00
+IOCB1  = $10
+IOCB2  = $20
+IOCB3  = $30
+IOCB4  = $40
+IOCB5  = $50
+IOCB6  = $60
+IOCB7  = $70
+
+
+; CIO Commands
+CIO_OPEN   = $03
+CIO_CLOSE  = $0C
+CIO_GET    = $07
+CIO_PUT    = $09
+CIO_INPUT  = $05
+CIO_PRINT  = $09
+CIO_STATUS = $0D
+
+; CIO Directions
+CIO_READ      = $04
+CIO_WRITE     = $08
+CIO_READWRITE = $0C
+
+ZEROPAGE
+
+.global ptr
+ptr:    .word 0
+
+zproc _start
+    ; Set screen color to white on black
+    lda #0
+    sta COLOR4                  ; Black background
+    sta COLOR2                  ; Grey hue
+    lda #$0F                    ; Highest luminance
+
+    ; Get an IOCB for the screen editor device
+    jsr get_free_iocb
+    stx editor_iocb
+
+    ; Load "E:" as the device name
+    lda #<editor_device
+    sta ICBAL,x
+    lda #>editor_decice
+    sta ICBAH,x
+
+
+
+loop:
+    jmp loop
+    rts
+zendproc
+
+zproc init_system
+
+zendproc
+
+
+; Finds a free IOCB and returns it in X. Returns $ff if there are no fre IOCBs.
+zproc get_free_iocb
+    ldy #0
+
+    zloop
+        tya                     ; Calculate IOCB offset
+        rol                     ; (y * 16)
+        rol
+        rol
+        rol
+        tax
+        lda ICHID,x             ; Load the IOCB handler
+
+        cmp #$ff                ;If the ID is $ff, it's available
+        zif_eq
+            rts
+        zendif
+
+        iny
+        cmp #$07
+        zif_eq
+            ldx #$ff            ; All channels are taken.
+            rts
+        zendif
+    zendloop
+zendproc
+
+editor_device:
+    .byte $45, $3A, EOL         ; ATASCII for 'E:\n'
+
+    .data
+zp_base:    .byte __USERZEROPAGE_START__
+zp_end:     .byte __USERZEROPAGE_END__
+
+NOINIT
+
+editor_iocb:    .byte 0         ; IOCB for screen editor

--- a/tools/mkatr.c
+++ b/tools/mkatr.c
@@ -1,0 +1,291 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <unistd.h>
+
+/** Atari disk image header. All fields are little endian.
+ *  The original ATR specification is kept to here, avoiding some of the
+ *  less compatible AtariMax extensions to the format. */
+struct ATRHeader
+{
+    /** Magic number, always set to 0x0296 */
+    uint16_t magic;
+
+    /** Size of the disk image in 'paragraphs'.
+     *  A Paragraph is a 16 byte block. */
+    uint16_t size;
+
+    /** Size in bytes of a sector in the image.
+     * 128 for single density and enhanced density
+     * 256 for double density.
+     * No matter the setting, the first 3 sectors should be 128 bytes long. */
+    uint16_t sector_size;
+
+    /** The high part of the size in paragraphs. */
+    uint16_t size_high;
+
+    /** Holds flags to indicate copy protection, write protect, etc. */
+    uint8_t flags;
+
+    /** Used for copy protection schemes. */
+    uint16_t first_bad_sector;
+
+    uint8_t unused[5];
+};
+
+struct ATRHeader *ATRHeader_new(uint32_t size_paragraphs,
+                                uint16_t sector_size)
+{
+    struct ATRHeader *header;
+    header = (struct ATRHeader*) malloc(sizeof(struct ATRHeader));
+
+    header->magic = 0x0296;
+    header->size = size_paragraphs & 0xFFFF;
+    header->size_high = size_paragraphs >> 16;
+    header->sector_size = sector_size;
+    header->flags = 0;
+    header->first_bad_sector = 0x0;
+
+    for(int i=0; i < 5; i++)
+    {
+        header->unused[i] = 0;
+    }
+
+
+    return header;
+}
+
+int write_uint8(uint8_t val, FILE *f)
+{
+    return fwrite(&val, sizeof(uint8_t), 1, f);
+}
+
+int write_uint16_le(uint16_t val, FILE *f)
+{
+    uint8_t out[2];
+    out[0] = val & 0xFF;
+    out[1] = val >> 8;
+    return fwrite(&val, sizeof(uint8_t), 1, f);
+}
+
+void ATRHeader_write(struct ATRHeader *header, FILE *f)
+{
+    write_uint16_le(header->magic, f);
+    write_uint16_le(header->size, f);
+    write_uint16_le(header->sector_size, f);
+    write_uint16_le(header->size_high, f);
+    write_uint8(header->flags, f);
+    write_uint16_le(header->first_bad_sector, f);
+
+    for(int i = 0; i < 5; i++)
+    {
+        write_uint8(header->unused[i], f);
+    }
+}
+
+/**
+ *  Write the boot record to the first sector of the disk.
+ *      num_sectors: number of sectors that the OS will load
+ *      load_address: the address that the boot record will be loaded to
+ *      init_address: the address that will be jumped to after a RET from the
+ *          boot sector.
+ */
+void write_boot_record(uint8_t num_sectors, uint16_t load_address,
+                       uint16_t init_address, FILE *f)
+{
+    /* First byte is always zero */
+    write_uint8(0x0, f);
+
+    write_uint8(num_sectors, f);
+    write_uint16_le(load_address, f);
+    write_uint16_le(init_address, f);
+}
+
+uint32_t write_boot_sectors(const uint8_t* data, size_t size,
+                            uint16_t load_address, uint16_t init_address,
+                            FILE* f)
+{
+    size_t boot_record_size = 6;
+    size_t total_size = boot_record_size = size;
+
+    // Pad out to the nearest sector
+    size_t padding = (0x80 - (total_size & 0x80)) & 0x7F;
+    uint32_t num_sectors = (total_size + padding) / 128;
+
+    write_boot_record(num_sectors, load_address, init_address, f);
+    fwrite(data, sizeof(uint8_t), size, f);
+
+    if(padding > 0) {
+        uint8_t* padding_bytes = (uint8_t *) calloc(padding, sizeof(uint8_t));
+        fwrite(padding_bytes, sizeof(uint8_t), padding, f);
+        free(padding_bytes);
+    }
+
+    return num_sectors;
+}
+
+size_t round_nearest_sector(size_t size)
+{
+    return ((0x80 - (size & 0x80)) & 0x7F) + size;
+}
+
+int write_disk_image(uint8_t* boot_sector_data, size_t boot_sector_size,
+    uint8_t* disk_data, size_t disk_data_size, uint16_t load_address,
+    uint16_t init_address, uint32_t disk_size, FILE* output_file)
+{
+    size_t total_size = 6 + round_nearest_sector(boot_sector_size)
+        + round_nearest_sector(disk_size);
+
+    if(total_size / 128 > disk_size)
+    {
+        fprintf(stderr, "Provided data is too large to fit on disk.\n");
+        return 1;
+    }
+
+    return 0;
+}
+
+void print_usage()
+{
+    fprintf(stderr,
+        "Usage:\n"
+        "\tmkatr -b <boot_sector_path> -d <disk_data_path> -l <load_address>\n"
+        "\t\t-i <init_address> -o <output_path> -s <disk_size_sectors>\n");
+}
+
+int parse_address(const char* address_str, uint16_t* address)
+{
+    uint16_t result = (uint16_t)strtol(address_str, NULL, 0);
+    if (result == 0)
+    {
+        return 1;
+    }
+    *address = result;
+    return 0;
+}
+
+int read_file(const char* path, uint8_t** data_ptr, size_t* size)
+{
+    FILE* fp;
+
+    fp = fopen(path, "r");
+    if (fp == NULL)
+    {
+        return 1;
+    }
+
+    fseek(fp, 0L, SEEK_END);
+    *size = ftell(fp);
+    fseek(fp, 0L, SEEK_SET);
+    *data_ptr = (uint8_t*)malloc(sizeof(uint8_t) * (*size));
+
+    if (*data_ptr == NULL)
+    {
+        return 1;
+    }
+
+    fclose(fp);
+    return 0;
+}
+
+int main(int argc, char* const argv[])
+{
+    int c;
+    uint16_t load_address = 0;
+    uint16_t init_address = 0;
+
+    uint8_t* boot_sector_data = NULL;
+    size_t boot_sector_size = 0;
+    uint8_t* disk_data = NULL;
+    size_t disk_data_size = 0;
+    FILE* output_file = NULL;
+
+    unsigned int disk_size = 0;
+
+    while ((c = getopt(argc, argv, "b:d:l:i:o:s:")) != -1)
+    {
+        switch (c)
+        {
+            case -1:
+                return 0;
+            case 'b':
+                if (read_file(optarg, &boot_sector_data, &boot_sector_size))
+                {
+                    fprintf(stderr,
+                        "Unable to open boot sector file at %s\n",
+                        optarg);
+                    exit(1);
+                }
+
+                break;
+            case 'd':
+                if (read_file(optarg, &disk_data, &disk_data_size))
+                {
+                    fprintf(stderr,
+                        "Unable to open disk data file at %s\n",
+                        optarg);
+                    exit(1);
+                }
+
+                break;
+            case 'l':
+                if (parse_address(optarg, &load_address))
+                {
+                    fprintf(stderr, "Invalid load address: %s\n", optarg);
+                    exit(1);
+                }
+                break;
+            case 'i':
+                if (parse_address(optarg, &init_address))
+                {
+                    fprintf(stderr, "Invalid init address: %s\n", optarg);
+                    exit(1);
+                }
+                break;
+            case 'o':
+                output_file = fopen(optarg, "w");
+                break;
+            case 's':
+                disk_size = strtoul(optarg, NULL, 0);
+                break;
+            default:
+                print_usage();
+                exit(1);
+        }
+    }
+
+    if (boot_sector_data == NULL || disk_data == NULL ||
+        load_address == 0 || init_address == 0 || output_file == NULL)
+    {
+        print_usage();
+        exit(1);
+    }
+
+    if(disk_size == 0)
+    {
+        // If a disk size is not provided, output an "enhanced density" (130K)
+        // disk compatible with an Atari 1050 drive.
+        disk_size = 1040;
+    } else if (disk_size > 0x20000) {
+        // 16MiB (131072 128 byte sectors) max size
+        fprintf(stderr, "Provided disk image size is too large.\n");
+    }
+
+    printf("%zu, %zu\n", boot_sector_size, disk_data_size);
+
+    int rv = write_disk_image(boot_sector_data,
+        boot_sector_size,
+        disk_data,
+        disk_data_size,
+        load_address,
+        init_address,
+        disk_size,
+        output_file);
+
+    fclose(output_file);
+    free(boot_sector_data);
+    free(disk_data);
+
+    return rv;
+}


### PR DESCRIPTION
This is just a placeholder for the port that I am working on for the Atari 8 bit line of machines.

My thoughts so far are to boot the bios directly from the boot sector of an Atari floppy. I was considering booting it directly from an Atari DOS formatted disk using the `AUTORUN.SYS` functionality that Atari DOS supports, and storing the CP/M filesystem inside of a regular file, like some of the other ports. This, however, would be a bit of a pain, as although the Atari supports random sector by sector reads, 3 bytes of each sector are taken up with a pointer to the next sector in the file. This means that if we want to read 128 bytes at a time, as required by CP/M, it would involve a lot of annoying maths.

I am planning to do screen updates with the Atari's CIO mechanism; screen updates will be done by writing to the virtual `S:` device, and keyboard input by reading from the `K:` device.