### PR TITLE
Add the device driver model.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ APPS = \
 	$(OBJDIR)/asm.com \
 	$(OBJDIR)/apps/bedit.com \
 	$(OBJDIR)/apps/dump.com \
+	$(OBJDIR)/apps/capsdrv.com \
 	apps/bedit.asm \
 	apps/dump.asm \
 	cpmfs/asm.txt \

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,11 @@ LIBCPM_OBJS = \
 
 LIBBIOS_OBJS = \
 	$(OBJDIR)/src/bios/biosentry.o \
+	$(OBJDIR)/src/bios/relocate.o \
+
+LIBCOMMODORE_OBJS = \
 	$(OBJDIR)/src/bios/commodore/ieee488.o \
 	$(OBJDIR)/src/bios/commodore/petscii.o \
-	$(OBJDIR)/src/bios/relocate.o \
 
 CPMEMU_OBJS = \
 	$(OBJDIR)/tools/cpmemu/main.o \
@@ -84,6 +86,10 @@ $(OBJDIR)/%.o: %.S include/zif.inc include/mos.inc include/cpm65.inc
 	@mkdir -p $(dir $@)
 	mos-cpm65-clang $(CFLAGS65) -c -o $@ $< -I include
 
+$(OBJDIR)/libcommodore.a: $(LIBCOMMODORE_OBJS)
+	@mkdir -p $(dir $@)
+	llvm-ar rs $@ $^
+
 $(OBJDIR)/libbios.a: $(LIBBIOS_OBJS)
 	@mkdir -p $(dir $@)
 	llvm-ar rs $@ $^
@@ -121,7 +127,7 @@ $(OBJDIR)/apple2e.bios: $(OBJDIR)/src/bios/apple2e.o $(OBJDIR)/libbios.a scripts
 	
 $(OBJDIR)/%.exe: $(OBJDIR)/src/bios/%.o $(OBJDIR)/libbios.a scripts/%.ld
 	@mkdir -p $(dir $@)
-	ld.lld -Map $(patsubst %.exe,%.map,$@) -T scripts/$*.ld -o $@ $< $(OBJDIR)/libbios.a $(LINKFLAGS)
+	ld.lld -Map $(patsubst %.exe,%.map,$@) -T scripts/$*.ld -o $@ $< $(filter %.a,$^) $(LINKFLAGS)
 
 $(OBJDIR)/4x8font.inc: bin/fontconvert third_party/tomsfonts/atari-small.bdf
 	@mkdir -p $(dir $@)
@@ -139,6 +145,7 @@ bbcmicro.ssd: $(OBJDIR)/bbcmicro.exe $(OBJDIR)/bdos.img Makefile $(OBJDIR)/bbcmi
 		-f $(OBJDIR)/bdos.img -n bdos \
 		-f $(OBJDIR)/bbcmicrofs.img -n cpmfs
 
+$(OBJDIR)/c64.exe: $(OBJDIR)/libcommodore.a
 c64.d64: $(OBJDIR)/c64.exe $(OBJDIR)/bdos.img Makefile $(APPS) $(OBJDIR)/ccp.sys \
 		$(OBJDIR)/mkcombifs
 	@rm -f $@
@@ -158,6 +165,7 @@ $(OBJDIR)/generic-1m-cpmfs.img: $(OBJDIR)/bdos.img $(APPS) $(OBJDIR)/ccp.sys
 	cpmcp -f generic-1m $@ $(OBJDIR)/ccp.sys $(APPS) 0:
 	cpmchattr -f generic-1m $@ s 0:ccp.sys
 
+$(OBJDIR)/x16.exe: $(OBJDIR)/libcommodore.a
 x16.zip: $(OBJDIR)/x16.exe $(OBJDIR)/bdos.img $(OBJDIR)/generic-1m-cpmfs.img
 	@rm -f $@
 	zip -9 $@ -j $^
@@ -181,6 +189,7 @@ apple2e.po: $(OBJDIR)/apple2e.boottracks $(OBJDIR)/bdos.img $(APPS) $(OBJDIR)/cc
 	truncate -s 143360 $@
 
 $(OBJDIR)/pet.exe: LINKFLAGS += --no-check-sections
+$(OBJDIR)/pet.exe: $(OBJDIR)/libcommodore.a
 pet.d64: $(OBJDIR)/pet.exe $(OBJDIR)/bdos.img Makefile $(APPS) $(OBJDIR)/ccp.sys \
 		$(OBJDIR)/mkcombifs
 	@rm -f $@
@@ -195,6 +204,7 @@ pet.d64: $(OBJDIR)/pet.exe $(OBJDIR)/bdos.img Makefile $(APPS) $(OBJDIR)/ccp.sys
 	cpmchattr -f c1541 $@ s 0:ccp.sys 0:ccp.sys
 
 $(OBJDIR)/vic20.exe: LINKFLAGS += --no-check-sections
+$(OBJDIR)/vic20.exe: $(OBJDIR)/libcommodore.a
 $(OBJDIR)/src/bios/vic20.o: $(OBJDIR)/4x8font.inc
 vic20.d64: $(OBJDIR)/vic20.exe $(OBJDIR)/bdos.img Makefile $(APPS) \
 		$(OBJDIR)/ccp.sys $(OBJDIR)/mkcombifs

--- a/apps/capsdrv.asm
+++ b/apps/capsdrv.asm
@@ -1,0 +1,172 @@
+
+\ This file is licensed under the terms of the 2-clause BSD license. Please
+\ see the COPYING file in the root project directory for the full text.
+
+.bss pblock, 165
+cpm_fcb = pblock
+cpm_default_dma = pblock + 0x25
+
+BDOS_WARMBOOT          =  0
+BDOS_CONIN             =  1
+BDOS_CONOUT            =  2
+BDOS_AUXIN             =  3
+BDOS_AUXOUT            =  4
+BDOS_LSTOUT            =  5
+BDOS_CONIO             =  6
+BDOS_GET_IOBYTE        =  7
+BDOS_SET_IOBYTE        =  8
+BDOS_PRINTSTRING       =  9
+BDOS_READLINE          = 10
+BDOS_CONST             = 11
+BDOS_GET_VERSION       = 12
+BDOS_RESET_DISK_SYSTEM = 13
+BDOS_SELECT_DRIVE      = 14
+BDOS_OPEN_FILE         = 15
+BDOS_CLOSE_FILE        = 16
+BDOS_FINDFIRST         = 17
+BDOS_FINDNEXT          = 18
+BDOS_DELETE_FILE       = 19
+BDOS_READ_SEQUENTIAL   = 20
+BDOS_WRITE_SEQUENTIAL  = 21
+BDOS_MAKE_FILE         = 22
+BDOS_RENAME_FILE       = 23
+BDOS_GET_LOGIN_VECTOR  = 24
+BDOS_GET_CURRENT_DRIVE = 25
+BDOS_SET_DMA           = 26
+BDOS_GET_ALLOC_VECTOR  = 27
+BDOS_WRITE_PROT_DRIVE  = 28
+BDOS_GET_READONLY_VEC  = 29
+BDOS_SET_FILE_ATTRS    = 30
+BDOS_GET_DPB           = 31
+BDOS_GET_SET_USER      = 32
+BDOS_READ_RANDOM       = 33
+BDOS_WRITE_RANDOM      = 34
+BDOS_SEEK_TO_END       = 35
+BDOS_SEEK_TO_SEQ_POS   = 36
+BDOS_RESET_DRIVES      = 37
+BDOS_GET_BIOS          = 38
+BDOS_WRITE_RANDOM_FILL = 40
+BDOS_GET_TPA           = 41
+BDOS_GET_ZP            = 42
+
+BIOS_CONST             = 0
+BIOS_CONIN             = 1
+BIOS_CONOUT            = 2
+BIOS_SELDSK            = 3
+BIOS_SETSEC            = 4
+BIOS_SETDMA            = 5
+BIOS_READ              = 6
+BIOS_WRITE             = 7
+BIOS_RELOCATE          = 8
+BIOS_GETTPA            = 9
+BIOS_SETTPA            = 10
+BIOS_GETZP             = 11
+BIOS_SETZP             = 12
+BIOS_SETBANK           = 13
+BIOS_ADDDRV            = 14
+BIOS_FINDDRV           = 15
+
+DRVID_TTY = 1
+
+TTY_CONST = 0
+TTY_CONIN = 1
+TTY_CONOUT = 2
+
+BDOS = start - 3
+start:
+.expand 1
+
+.label entry
+.label next
+
+\ --- Resident part starts at the top of the file ---------------------------
+
+.zproc main
+    jmp entry
+.zendproc
+
+driver:
+    .word DRVID_TTY
+    .word strategy
+    .word 0
+    .byte "CapsTTY", 0
+
+.zproc strategy
+    cpy #TTY_CONOUT
+    .zif eq
+        cmp #'a'
+        .zif cs
+            cmp #'z'+1
+            .zif cc
+                and #0xdf
+            .zendif
+        .zendif
+    .zendif
+    jmp (next)
+.zendproc
+
+next: .word 0
+
+\ --- Resident part stops here -------------------------------------------
+
+.zproc entry
+    lda #<banner
+    ldx #>banner
+    ldy #BDOS_PRINTSTRING
+    jsr BDOS
+
+    ldy #BDOS_GET_BIOS
+    jsr BDOS
+    sta BIOS+1
+    stx BIOS+2
+
+    \ Find the old TTY driver strategy routine and save it.
+
+    lda #<DRVID_TTY
+    ldx #>DRVID_TTY
+    ldy #BIOS_FINDDRV
+    jsr BIOS
+    .zif cc
+        sta next+0
+        stx next+1
+
+        \ Register the new TTY driver.
+
+        lda #<driver
+        ldx #>driver
+        ldy #BIOS_ADDDRV
+        jsr BIOS
+        .zif cc
+
+            \ Our driver uses no ZP, so we don't need to adjust that. But it does use
+            \ TPA.
+
+            ldy #BIOS_GETTPA
+            jsr BIOS
+            clc
+            adc #1 \ Allocate one page. We should be using entry to calculate this, but
+                   \ the assembler can't do that yet.
+            ldy #BIOS_SETTPA
+            jsr BIOS
+
+            \ Finished --- don't even need to warm boot.
+
+            rts
+        .zendif
+    .zendif
+
+    lda #<failed
+    ldx #>failed
+    ldy #BDOS_PRINTSTRING
+    jmp BDOS
+    
+banner:
+    .byte "Everything is in capital letters now", 13, 10, 0
+failed:
+    .byte "Failed!", 13, 10, 0
+BIOS:
+    jmp 0
+
+\ vim: sw=4 ts=4 et
+
+

--- a/include/cpm65.inc
+++ b/include/cpm65.inc
@@ -118,8 +118,8 @@
 #define BIOS_GETZP    11 /* gets ZP bounds: A=lo, X=hi */
 #define BIOS_SETZP    12 /* sets ZP bounds: A=lo, X=hi */
 #define BIOS_SETBANK  13 /* sets current memory bank */
-#define BIOS_ADDDRV   14 /* entry: XA=new driver; exit: XA=old driver */
-#define BIOS_FINDDRV  15 /* entry: XA=driver ID; exit: XA=driver routine */
+#define BIOS_ADDDRV   14 /* entry: XA=new driver */
+#define BIOS_FINDDRV  15 /* entry: XA=driver ID; exit: XA=driver strategy routine */
 
 /* Memory banks. */
 

--- a/include/cpm65.inc
+++ b/include/cpm65.inc
@@ -88,6 +88,8 @@
 #define BDOS_RESET_DISK 37
 #define BDOS_GET_BIOS 38
 #define BDOS_WRITE_RANDOM_FILLED 40
+#define BDOS_GETTPA 41
+#define BDOS_GETZP 42
 
 /* Error codes returned by various BDOS entrypoints. */
 
@@ -116,6 +118,8 @@
 #define BIOS_GETZP    11 /* gets ZP bounds: A=lo, X=hi */
 #define BIOS_SETZP    12 /* sets ZP bounds: A=lo, X=hi */
 #define BIOS_SETBANK  13 /* sets current memory bank */
+#define BIOS_ADDDRV   14 /* entry: XA=new driver; exit: XA=old driver */
+#define BIOS_FINDDRV  15 /* entry: XA=driver ID; exit: XA=driver routine */
 
 /* Memory banks. */
 

--- a/include/driver.inc
+++ b/include/driver.inc
@@ -8,11 +8,34 @@
 #define DRVID_SCREEN 2
 #define DRVID_BLOCK  3
 
-; Driver management routine Y values.
+; Driver structure:
+;
+;  +0  driver ID
+;  +2  pointer to strategy routine
+;  +4  pointer to next driver, or 0; filled in when added
+;  +6  zero-terminated name starts here
 
-#define DRVCMD_FIND  0 /* entry: XA=driver ID; exit: XA=strategy routine */
-#define DRVCMD_NAME  1 /* exit: XA=pointer to string */
-#define DRVCMD_NEXT  2 /* exit: XA=next management routine */
+#define DRVSTRUCT_ID    0
+#define DRVSTRUCT_STRAT 2
+#define DRVSTRUCT_NEXT  4
+#define DRVSTRUCT_NAME  6
+
+.macro defdriver name, id, strat, next=0
+.data
+.global drv_\name
+drv_\name:
+    .word \id
+    .word \strat
+    .word \next
+    .ascii "\name"
+    .byte 0
+.endmacro
+
+; TTY driver entrypoints
+
+#define TTY_CONST 0  /* exit: C if no key pending, !C if key pending */
+#define TTY_CONIN 1  /* exit: A=key */
+#define TTY_CONOUT 2 /* entry: A=key */
 
 ; vim: filetype=asm sw=4 ts=4 et
 

--- a/include/driver.inc
+++ b/include/driver.inc
@@ -1,0 +1,18 @@
+; CP/M-65 Copyright © 2023 David Given
+; This file is licensed under the terms of the 2-clause BSD license. Please
+; see the COPYING file in the root project directory for the full text.
+
+; 16-bit driver IDs.
+
+#define DRVID_TTY    1
+#define DRVID_SCREEN 2
+#define DRVID_BLOCK  3
+
+; Driver management routine Y values.
+
+#define DRVCMD_FIND  0 /* entry: XA=driver ID; exit: XA=strategy routine */
+#define DRVCMD_NAME  1 /* exit: XA=pointer to string */
+#define DRVCMD_NEXT  2 /* exit: XA=next management routine */
+
+; vim: filetype=asm sw=4 ts=4 et
+

--- a/include/zif.inc
+++ b/include/zif.inc
@@ -10,9 +10,9 @@
 .set zloopsp, 0
 .set zifsp, 0
 
-.macro zproc name, section=.text
+.macro zproc name, section=.text, binding=global
     .section \section, "ax"
-    .global \name
+    .\binding \name
     \name:
 .endm
 

--- a/src/bios/apple2e.S
+++ b/src/bios/apple2e.S
@@ -5,6 +5,7 @@
 #include "zif.inc"
 #include "cpm65.inc"
 #include "wait.inc"
+#include "driver.inc"
 
 SCREEN_80STOREOFF = 0xc000
 SCREEN_80STOREON  = 0xc001
@@ -48,6 +49,7 @@ DECODE_TABLE_START = 0x96
 ZEROPAGE
 
 .global ptr
+.global ptr1
 ptr:    .word 0
 ptr1:   .word 0
 dma:    .word 0
@@ -90,6 +92,10 @@ _start:
             zbreakif_eq
         zendif
     zendloop
+
+    ; Initialise it.
+
+    jsr initdrivers
 
     ; Print the startup banner.
 
@@ -228,11 +234,38 @@ zproc entry_SETBANK
     rts
 zendproc
 
-; --- Screen ----------------------------------------------------------------
+; --- TTY driver ------------------------------------------------------------
+
+.data
+.global drvtop
+drvtop: .word drv_TTY
+
+defdriver TTY, DRVID_TTY, drvstrat_TTY, 0
+
+; TTY driver strategy routine.
+; Y=TTY opcode.
+zproc drvstrat_TTY
+    pha
+    lda jmptable_lo, y
+    sta ptr+0
+    lda jmptable_hi, y
+    sta ptr+1
+    pla
+    jmp (ptr)
+
+jmptable_lo:
+    .byte tty_const@mos16lo
+    .byte tty_conin@mos16lo
+    .byte tty_conout@mos16lo
+jmptable_hi:
+    .byte tty_const@mos16hi
+    .byte tty_conin@mos16hi
+    .byte tty_conout@mos16hi
+zendproc
 
 ; Writes the character in A.
 
-zproc entry_CONOUT
+zproc tty_conout
     cmp #13
     zif_eq
         lda #0
@@ -395,7 +428,7 @@ zendproc
 
 ; --- Keyboard --------------------------------------------------------------
 
-zproc entry_CONST
+zproc tty_const
     ldx motor_countdown
     zif_ne
         dec motor_countdown
@@ -416,7 +449,7 @@ zproc entry_CONST
     rts
 zendproc
 
-zproc entry_CONIN
+zproc tty_conin
     ; Turn the disk motor off.
 
     ldx #DISK_SLOT

--- a/src/bios/bbcmicro.S
+++ b/src/bios/bbcmicro.S
@@ -5,11 +5,14 @@
 #include "zif.inc"
 #include "mos.inc"
 #include "cpm65.inc"
+#include "driver.inc"
 
 ZEROPAGE
 
 .global ptr
+.global ptr1
 ptr: .word 0
+ptr1: .word 0
 
 ; --- Initialisation code ---------------------------------------------------
 
@@ -42,6 +45,10 @@ zproc _start
         sta zp_end      ; override zp_end
     zendif
     sty mem_end
+
+    ; BIOS initialisation.
+
+    jsr initdrivers
 
     ; Load the BDOS image.
 
@@ -108,52 +115,38 @@ cpmfs_filename:
     .ascii "CPMFS"
     .byte 13
 
-; --- BIOS entrypoints ------------------------------------------------------
+.data
+.global drvtop
+drvtop: .word drv_TTY
 
-; BIOS entry point. Parameter is in XA, function in Y.
-biosentry:
+; --- TTY driver ------------------------------------------------------------
+
+defdriver TTY, DRVID_TTY, drvstrat_TTY, 0
+
+; TTY driver strategy routine.
+; Y=TTY opcode.
+zproc drvstrat_TTY
     pha
-    lda biostable_lo, y
+    lda jmptable_lo, y
     sta ptr+0
-    lda biostable_hi, y
+    lda jmptable_hi, y
     sta ptr+1
     pla
     jmp (ptr)
 
-biostable_lo:
-    .byte entry_CONST@mos16lo
-    .byte entry_CONIN@mos16lo
+jmptable_lo:
+    .byte tty_const@mos16lo
+    .byte tty_conin@mos16lo
     .byte OSWRCH@mos16lo
-    .byte entry_SELDSK@mos16lo
-    .byte entry_SETSEC@mos16lo
-    .byte entry_SETDMA@mos16lo
-    .byte entry_READ@mos16lo
-    .byte entry_WRITE@mos16lo
-    .byte entry_RELOCATE@mos16lo
-    .byte entry_GETTPA@mos16lo
-    .byte entry_SETTPA@mos16lo
-    .byte entry_GETZP@mos16lo
-    .byte entry_SETZP@mos16lo
-    .byte entry_SETBANK@mos16lo
-biostable_hi:
-    .byte entry_CONST@mos16hi
-    .byte entry_CONIN@mos16hi
+jmptable_hi:
+    .byte tty_const@mos16hi
+    .byte tty_conin@mos16hi
     .byte OSWRCH@mos16hi
-    .byte entry_SELDSK@mos16hi
-    .byte entry_SETSEC@mos16hi
-    .byte entry_SETDMA@mos16hi
-    .byte entry_READ@mos16hi
-    .byte entry_WRITE@mos16hi
-    .byte entry_RELOCATE@mos16hi
-    .byte entry_GETTPA@mos16hi
-    .byte entry_SETTPA@mos16hi
-    .byte entry_GETZP@mos16hi
-    .byte entry_SETZP@mos16hi
-    .byte entry_SETBANK@mos16hi
+zendproc
 
 ; Blocks and waits for the next keypress; returns it in A.
 
-zproc entry_CONIN
+zproc tty_conin
     lda pending_key
     zif_eq
         zrepeat
@@ -171,7 +164,7 @@ zproc entry_CONIN
     rts
 zendproc
 
-zproc entry_CONST
+zproc tty_const
     lda pending_key
     zif_eq
         lda #$81
@@ -229,12 +222,13 @@ zproc entry_SETSEC
     rts
 zendproc
 
-entry_READ:
+zproc entry_READ
     jsr init_control_block
     lda #3              ; read bytes using pointer
     jmp do_gbpb
+zendproc
 
-entry_WRITE:
+zproc entry_WRITE
     jsr init_control_block
     lda #1              ; write bytes using pointer
 do_gbpb:
@@ -244,6 +238,7 @@ do_gbpb:
     lda #0
     rol a
     rts
+zendproc
 
 zproc init_control_block
     ldy #(osgbpb_block_end - osgbpb_block - 1)

--- a/src/bios/biosentry.S
+++ b/src/bios/biosentry.S
@@ -5,6 +5,9 @@
 #include "zif.inc"
 #include "mos.inc"
 #include "cpm65.inc"
+#include "driver.inc"
+
+.global drvtop
 
 ; BIOS entry point. Parameter is in XA, function in Y.
 zproc biosentry
@@ -31,6 +34,8 @@ biostable_lo:
     .byte entry_GETZP@mos16lo
     .byte entry_SETZP@mos16lo
     .byte entry_SETBANK@mos16lo
+	.byte entry_ADDDRV@mos16lo
+	.byte entry_FINDDRV@mos16lo
 biostable_hi:
     .byte entry_CONST@mos16hi
     .byte entry_CONIN@mos16hi
@@ -46,6 +51,117 @@ biostable_hi:
     .byte entry_GETZP@mos16hi
     .byte entry_SETZP@mos16hi
     .byte entry_SETBANK@mos16hi
+	.byte entry_ADDDRV@mos16hi
+	.byte entry_FINDDRV@mos16hi
 zendproc
 
+zproc entry_ADDDRV
+	sta ptr+0			; save new driver address
+	stx ptr+1
 
+	ldy #DRVSTRUCT_NEXT
+	lda drvtop+0		; get old driver address
+	sta (ptr), y
+	iny
+	lda drvtop+1
+	sta (ptr), y
+
+	ldy ptr+0			; update address
+	sty drvtop+0
+	ldy ptr+1
+	sty drvtop+1
+
+	pha
+	txa
+	pha
+	jsr initdrivers
+	pla
+	tax
+	pla
+	rts
+zendproc
+
+zproc entry_FINDDRV
+	sta ptr1+0
+	stx ptr1+1
+
+	lda drvtop+0
+	sta ptr+0
+	lda drvtop+1
+	sta ptr+1
+
+	zloop
+		; Stop if no more drivers.
+
+		lda ptr+0
+		ora ptr+1
+		zif_eq
+			sec
+			rts
+		zendif
+
+		; Check this driver's ID.
+
+		ldy #DRVSTRUCT_ID
+		lda (ptr), y
+		cmp ptr1+0
+		zif_eq
+			iny
+			lda (ptr), y
+			cmp ptr1+1
+			zif_eq
+				; Found a matching driver, so return its strategy routine.
+
+				iny
+				iny
+				lda (ptr), y
+				tax
+				dey
+				lda (ptr), y
+				clc
+				rts
+			zendif
+		zendif
+
+		; This driver doesn't match, so continue on down the list.
+
+		ldy #DRVSTRUCT_NEXT
+		lda (ptr), y
+		tax
+		iny
+		lda (ptr), y
+		sta ptr+1
+		stx ptr+0
+	zendloop
+zendproc
+
+; Recache driver pointers.
+
+zproc initdrivers
+	lda #<DRVID_TTY
+	ldx #>DRVID_TTY
+	jsr entry_FINDDRV
+	sta drv_tty+0
+	stx drv_tty+1
+	rts
+zendproc
+
+; TTY routine implementations which delegate to a driver.
+
+zproc entry_CONST
+	ldy #TTY_CONST
+	jmp (drv_tty)
+zendproc
+
+zproc entry_CONIN
+	ldy #TTY_CONIN
+	jmp (drv_tty)
+zendproc
+
+zproc entry_CONOUT
+	ldy #TTY_CONOUT
+	jmp (drv_tty)
+zendproc
+
+.bss
+drv_tty: .fill 2

--- a/src/bios/c64.S
+++ b/src/bios/c64.S
@@ -4,6 +4,7 @@
 
 #include "zif.inc"
 #include "cpm65.inc"
+#include "driver.inc"
 
 READST = $ffb7
 SETLFS = $ffba
@@ -33,7 +34,9 @@ STATUS = $90
 ZEROPAGE
 
 .global ptr
+.global ptr1
 ptr:        .word 0
+ptr1:       .word 0
 dma:        .word 0    ; current DMA
 
     .text
@@ -122,52 +125,36 @@ bdos_filename_end:
 bdos_filename_len = bdos_filename_end - bdos_filename
 zendproc
 
-; --- BIOS entrypoints ------------------------------------------------------
+.data
+.global drvtop
+drvtop: .word drv_TTY
 
-; BIOS entry point. Parameter is in XA, function in Y.
-biosentry:
+defdriver TTY, DRVID_TTY, drvstrat_TTY, 0
+
+; TTY driver strategy routine.
+; Y=TTY opcode.
+zproc drvstrat_TTY
     pha
-    lda biostable_lo, y
+    lda jmptable_lo, y
     sta ptr+0
-    lda biostable_hi, y
+    lda jmptable_hi, y
     sta ptr+1
     pla
     jmp (ptr)
 
-biostable_lo:
-    .byte entry_CONST    @mos16lo
-    .byte entry_CONIN    @mos16lo
-    .byte entry_CONOUT   @mos16lo
-    .byte entry_SELDSK   @mos16lo
-    .byte entry_SETSEC   @mos16lo
-    .byte entry_SETDMA   @mos16lo
-    .byte entry_READ     @mos16lo
-    .byte entry_WRITE    @mos16lo
-    .byte entry_RELOCATE @mos16lo
-    .byte entry_GETTPA   @mos16lo
-    .byte entry_SETTPA   @mos16lo
-    .byte entry_GETZP    @mos16lo
-    .byte entry_SETZP    @mos16lo
-    .byte entry_SETBANK  @mos16lo
-biostable_hi:
-    .byte entry_CONST    @mos16hi
-    .byte entry_CONIN    @mos16hi
-    .byte entry_CONOUT   @mos16hi
-    .byte entry_SELDSK   @mos16hi
-    .byte entry_SETSEC   @mos16hi
-    .byte entry_SETDMA   @mos16hi
-    .byte entry_READ     @mos16hi
-    .byte entry_WRITE    @mos16hi
-    .byte entry_RELOCATE @mos16hi
-    .byte entry_GETTPA   @mos16hi
-    .byte entry_SETTPA   @mos16hi
-    .byte entry_GETZP    @mos16hi
-    .byte entry_SETZP    @mos16hi
-    .byte entry_SETBANK  @mos16hi
+jmptable_lo:
+    .byte tty_const@mos16lo
+    .byte tty_conin@mos16lo
+    .byte tty_conout@mos16lo
+jmptable_hi:
+    .byte tty_const@mos16hi
+    .byte tty_conin@mos16hi
+    .byte tty_conout@mos16hi
+zendproc
 
 ; Blocks and waits for the next keypress; returns it in A.
 
-zproc entry_CONIN
+zproc tty_conin
     lda pending_key
     zif_eq
         zrepeat
@@ -187,14 +174,14 @@ zproc entry_CONIN
     rts
 zendproc
 
-zproc entry_CONOUT
+zproc tty_conout
     jsr topetscii
     jsr CHROUT
     clc
     rts
 zendproc
 
-zproc entry_CONST
+zproc tty_const
     lda pending_key
     zif_eq
         jsr GETIN
@@ -680,6 +667,8 @@ zproc init_system
     sta buffered_sector+0
     sta buffered_sector+1
     sta buffered_sector+2
+
+    jsr initdrivers
 
     lda #8
     jsr LISTEN

--- a/src/bios/pet.S
+++ b/src/bios/pet.S
@@ -4,6 +4,7 @@
 
 #include "zif.inc"
 #include "cpm65.inc"
+#include "driver.inc"
 
 PIA1    = 0xe810
 PIA1_PA = PIA1 + 0
@@ -45,6 +46,7 @@ VIDEO   = 0x8000
 ZEROPAGE
 
 .global ptr
+.global ptr1
 ptr:              .fill 2
 ptr1:             .fill 2
 dma:              .fill 2    ; current DMA
@@ -146,7 +148,7 @@ zproc _start, .init
         tya
         pha
         lda banner-1, y
-        jsr entry_CONOUT
+        jsr tty_conout
         pla
         tay
         dey
@@ -158,6 +160,7 @@ zproc _start, .init
     sta shift_pressed
     sta pending_key
     sta buffer_dirty
+    jsr initdrivers
 
     jsr ieee_init
 
@@ -202,7 +205,7 @@ zproc _start, .init
             tya
             pha
             lda #'.'
-            jsr entry_CONOUT
+            jsr tty_conout
             pla
             tay
         zendif
@@ -287,9 +290,36 @@ zendproc
 
 ; --- Keyboard handling -----------------------------------------------------
 
+.data
+.global drvtop
+drvtop: .word drv_TTY
+
+defdriver TTY, DRVID_TTY, drvstrat_TTY, 0
+
+; TTY driver strategy routine.
+; Y=TTY opcode.
+zproc drvstrat_TTY
+    pha
+    lda jmptable_lo, y
+    sta ptr+0
+    lda jmptable_hi, y
+    sta ptr+1
+    pla
+    jmp (ptr)
+
+jmptable_lo:
+    .byte tty_const@mos16lo
+    .byte tty_conin@mos16lo
+    .byte tty_conout@mos16lo
+jmptable_hi:
+    .byte tty_const@mos16hi
+    .byte tty_conin@mos16hi
+    .byte tty_conout@mos16hi
+zendproc
+
 ; Returns 0xff if no key is pending, 0 if one is.
 
-zproc entry_CONST
+zproc tty_const
     jsr scan_keyboard
 
     lda pending_key
@@ -303,7 +333,7 @@ zendproc
 
 ; Blocks until a key is pressed; returns it in A.
 
-zproc entry_CONIN
+zproc tty_conin
     jsr calculate_cursor_address
     lda (ptr), y
     eor #0x80
@@ -454,7 +484,7 @@ zendproc
 
 ; Writes the character in A.
 
-zproc entry_CONOUT
+zproc tty_conout
     cmp #13
     zif_eq
         lda #0

--- a/src/bios/vic20.S
+++ b/src/bios/vic20.S
@@ -5,6 +5,7 @@
 #include "zif.inc"
 #include "cpm65.inc"
 #include "wait.inc"
+#include "driver.inc"
 
 ;https://www.antimon.org/dl/c64/code/stable.txt
 
@@ -135,6 +136,7 @@ zproc _init, .init
     lda #0x08           ; black border, black background, inverted
     sta 0x900f
 
+    jsr initdrivers
     jsr clear_screen
 
     ldy #banner_end - banner
@@ -285,9 +287,36 @@ zendproc
 
 ; --- Keyboard handling -----------------------------------------------------
 
+.data
+.global drvtop
+drvtop: .word drv_TTY
+
+defdriver TTY, DRVID_TTY, drvstrat_TTY, 0
+
+; TTY driver strategy routine.
+; Y=TTY opcode.
+zproc drvstrat_TTY
+    pha
+    lda jmptable_lo, y
+    sta ptr+0
+    lda jmptable_hi, y
+    sta ptr+1
+    pla
+    jmp (ptr)
+
+jmptable_lo:
+    .byte tty_const@mos16lo
+    .byte tty_conin@mos16lo
+    .byte tty_conout@mos16lo
+jmptable_hi:
+    .byte tty_const@mos16hi
+    .byte tty_conin@mos16hi
+    .byte tty_conout@mos16hi
+zendproc
+
 ; Returns 0xff if no key is pending, 0 if one is.
 
-zproc entry_CONST
+zproc tty_const
     jsr scan_keyboard
 
     lda pending_key
@@ -301,7 +330,7 @@ zendproc
 
 ; Blocks until a key is pressed; returns it in A.
 
-zproc entry_CONIN
+zproc tty_conin
     jsr toggle_cursor
 
     lda pending_key
@@ -456,7 +485,7 @@ zendproc
 
 ; Writes the character in A.
 
-zproc entry_CONOUT
+zproc tty_conout
     cmp #13
     zif_eq
         lda #0
@@ -1108,6 +1137,7 @@ zendproc
 ZEROPAGE
 
 .global ptr
+.global ptr1
 ptr:             .fill 2
 ptr1:            .fill 2
 ptr2:            .fill 2

--- a/src/bios/x16.S
+++ b/src/bios/x16.S
@@ -4,6 +4,7 @@
 
 #include "zif.inc"
 #include "cpm65.inc"
+#include "driver.inc"
 
 READST = $ffb7
 SETLFS = $ffba
@@ -34,7 +35,9 @@ STATUS = $0287
 ZEROPAGE
 
 .global ptr
+.global ptr1
 ptr: .fill 2
+ptr1: .fill 2
 dma: .fill 2 ; current DMA address
 
 ; BASIC loader and relocator. Needs to start at 0x7ff.
@@ -89,6 +92,10 @@ _start:
 		lda destp+1
 		cmp #>__bios_end
 		bne 1b
+
+	; BIOS initialisation.
+
+	jsr initdrivers
 
     ; Open the BDOS file (using low level disk access).
 
@@ -193,52 +200,36 @@ cpmfs_filename_len = cpmfs_filename_end - cpmfs_filename
 
 .text
 
-; --- BIOS entrypoints ------------------------------------------------------
+.data
+.global drvtop
+drvtop: .word drv_TTY
 
-; BIOS entry point. Parameter is in XA, function in Y.
-biosentry:
+defdriver TTY, DRVID_TTY, drvstrat_TTY, 0
+
+; TTY driver strategy routine.
+; Y=TTY opcode.
+zproc drvstrat_TTY
     pha
-    lda biostable_lo, y
+    lda jmptable_lo, y
     sta ptr+0
-    lda biostable_hi, y
+    lda jmptable_hi, y
     sta ptr+1
     pla
     jmp (ptr)
 
-biostable_lo:
-    .byte entry_CONST    @mos16lo
-    .byte entry_CONIN    @mos16lo
-    .byte entry_CONOUT   @mos16lo
-    .byte entry_SELDSK   @mos16lo
-    .byte entry_SETSEC   @mos16lo
-    .byte entry_SETDMA   @mos16lo
-    .byte entry_READ     @mos16lo
-    .byte entry_WRITE    @mos16lo
-    .byte entry_RELOCATE @mos16lo
-    .byte entry_GETTPA   @mos16lo
-    .byte entry_SETTPA   @mos16lo
-    .byte entry_GETZP    @mos16lo
-    .byte entry_SETZP    @mos16lo
-    .byte entry_SETBANK  @mos16lo
-biostable_hi:
-    .byte entry_CONST    @mos16hi
-    .byte entry_CONIN    @mos16hi
-    .byte entry_CONOUT   @mos16hi
-    .byte entry_SELDSK   @mos16hi
-    .byte entry_SETSEC   @mos16hi
-    .byte entry_SETDMA   @mos16hi
-    .byte entry_READ     @mos16hi
-    .byte entry_WRITE    @mos16hi
-    .byte entry_RELOCATE @mos16hi
-    .byte entry_GETTPA   @mos16hi
-    .byte entry_SETTPA   @mos16hi
-    .byte entry_GETZP    @mos16hi
-    .byte entry_SETZP    @mos16hi
-    .byte entry_SETBANK  @mos16hi
+jmptable_lo:
+    .byte tty_const@mos16lo
+    .byte tty_conin@mos16lo
+    .byte tty_conout@mos16lo
+jmptable_hi:
+    .byte tty_const@mos16hi
+    .byte tty_conin@mos16hi
+    .byte tty_conout@mos16hi
+zendproc
 
 ; Blocks and waits for the next keypress; returns it in A.
 
-zproc entry_CONIN
+zproc tty_conin
     lda pending_key
     zif_eq
         zrepeat
@@ -258,14 +249,14 @@ zproc entry_CONIN
     rts
 zendproc
 
-zproc entry_CONOUT
+zproc tty_conout
     jsr topetscii
     jsr CHROUT
     clc
     rts
 zendproc
 
-zproc entry_CONST
+zproc tty_const
     lda pending_key
     zif_eq
         jsr GETIN


### PR DESCRIPTION
It's not quite the same as #23, as I realised it would use about 32 bytes of boilerplate per driver. The BIOS cost is now higher, but the per-driver cost is lower.

The BIOS TTY functions now redirect through the TTY driver. A sample TSR drive is supplied which wraps this and capitalises all printed text.