### PR TITLE
Fix two C64 bugs:

### DIFF
--- a/src/bios/biosentry.S
+++ b/src/bios/biosentry.S
@@ -151,8 +151,8 @@ zproc initdrivers
 	lda #<DRVID_TTY
 	ldx #>DRVID_TTY
 	jsr entry_FINDDRV
-	sta drv_tty+0
-	stx drv_tty+1
+	sta TTY+1
+	stx TTY+2
 	rts
 zendproc
 
@@ -160,18 +160,18 @@ zendproc
 
 zproc entry_CONST
 	ldy #TTY_CONST
-	jmp (drv_tty)
+	jmp TTY
 zendproc
 
 zproc entry_CONIN
 	ldy #TTY_CONIN
-	jmp (drv_tty)
+	jmp TTY
 zendproc
 
 zproc entry_CONOUT
 	ldy #TTY_CONOUT
-	jmp (drv_tty)
 zendproc
-
-.bss
-drv_tty: .fill 2
+	; fall through
+zproc TTY
+	jmp 0xffff
+zendproc

--- a/src/bios/c64.S
+++ b/src/bios/c64.S
@@ -69,25 +69,22 @@ zproc _start
 
     ; Read the data.
 
-    lda #<__USERTPA_START__
-    sta ptr+0
-    lda #>__USERTPA_START__
-    sta ptr+1
-
     lda #8
     jsr TALK
     lda #$60            ; emit channel 0
     jsr TALKSA
 
-    ldy #0
     zrepeat
+        ldy #0
         sty STATUS
         jsr ACPTR       ; read a byte
-        sta (ptr), y
 
-        inc ptr+0
+    1:
+        sta __USERTPA_START__
+
+        inc 1b+1
         zif_eq
-            inc ptr+1
+            inc 1b+2
             lda #'.'
             jsr entry_CONOUT
         zendif


### PR DESCRIPTION
- don't use jmp (abs) due to the famous (not to me) 6502 bug
- don't try to use the same pointer for two things at once while loading the BDOS
