### PR TITLE
Rework the SCREEN driver definition to be more user friendly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ apple2e.po: $(OBJDIR)/apple2e.boottracks $(OBJDIR)/bdos.img $(APPS) $(OBJDIR)/cc
 
 $(OBJDIR)/pet.exe: LINKFLAGS += --no-check-sections
 $(OBJDIR)/pet.exe: $(OBJDIR)/libcommodore.a
-pet.d64: $(OBJDIR)/pet.exe $(OBJDIR)/bdos.img Makefile $(APPS) $(OBJDIR)/ccp.sys \
+pet.d64: $(OBJDIR)/pet.exe $(OBJDIR)/bdos.img Makefile $(APPS) $(SCREEN_APPS) $(OBJDIR)/ccp.sys \
 		$(OBJDIR)/mkcombifs
 	@rm -f $@
 	cc1541 -i 15 -q -n "cp/m-65" $@
@@ -230,7 +230,7 @@ pet.d64: $(OBJDIR)/pet.exe $(OBJDIR)/bdos.img Makefile $(APPS) $(OBJDIR)/ccp.sys
 		-r 18 -s 1 -f bdos -w $(OBJDIR)/bdos.img \
 		$@
 	$(OBJDIR)/mkcombifs $@
-	cpmcp -f c1541 $@ $(OBJDIR)/ccp.sys $(APPS) 0:
+	cpmcp -f c1541 $@ $(OBJDIR)/ccp.sys $(APPS) $(SCREEN_APPS) 0:
 	cpmchattr -f c1541 $@ sr 0:ccp.sys 0:ccp.sys
 
 $(OBJDIR)/vic20.exe: LINKFLAGS += --no-check-sections

--- a/apps/qe.c
+++ b/apps/qe.c
@@ -690,7 +690,7 @@ void insert_mode(bool replacing)
             break;
 
         dirty = true;
-        if (c == 8)
+        if (c == 127)
         {
             if (gap_start != current_line)
                 gap_start--;

--- a/apps/qe.c
+++ b/apps/qe.c
@@ -150,7 +150,7 @@ void set_status_line(const char* message)
 
     uint8_t length = 0;
     goto_status_line();
-    // con_revon();
+	screen_setstyle(1);
     for (;;)
     {
         char c = *message++;
@@ -159,7 +159,7 @@ void set_status_line(const char* message)
         screen_putchar(c);
         length++;
     }
-    // con_revoff();
+	screen_setstyle(0);
     while (length < status_line_length)
     {
         screen_putchar(' ');

--- a/include/driver.inc
+++ b/include/driver.inc
@@ -92,5 +92,11 @@ drv_\name:
 
 #define SCREEN_CLEARTOEOL 11
 
+; Sets the style bitmap. If not supported, a platform will ignore a given
+; style.
+#define STYLE_REVERSE 1
+
+#define SCREEN_SETSTYLE   12
+
 ; vim: filetype=asm sw=4 ts=4 et
 

--- a/include/driver.inc
+++ b/include/driver.inc
@@ -45,15 +45,13 @@ drv_\name:
 #define SCREEN_CLEAR       2 /* also homes cursor */
 #define SCREEN_SETCURSOR   3 /* entry: A=x, X=y; out of bounds undefined */
 #define SCREEN_GETCURSOR   4 /* exit: A=x, X=y */
-#define SCREEN_PUTCHAR     5 /* entry: A=char; moves cursor to right, possibly scrolling */
-#define SCREEN_PUTSTRING   6 /* entry: XA=nul terminated pointer */
+#define SCREEN_PUTCHAR     5 /* entry: A=char; moves cursor to right, unless at edge of screen */
+#define SCREEN_PUTSTRING   6 /* entry: XA=nul terminated pointer; as above */
 #define SCREEN_GETCHAR     7 /* entry: XA=timeoutin cs, exit: A=char, or C if timed out */
 #define SCREEN_SHOWCURSOR  8 /* entry: A=0 for off, non-zero for on */
 #define SCREEN_SCROLLUP    9 /* cursor position left undefined */
 #define SCREEN_SCROLLDOWN 10 /* cursor position left undefined */
 #define SCREEN_CLEARTOEOL 11 /* from cursor position to EOL */
-#define SCREEN_NEWLINE    12 /* does a newline, possibly scrolling */
-#define SCREEN_BACKSPACE  13 /* does a backspace-and-erase, possibly scrolling */
 
 ; vim: filetype=asm sw=4 ts=4 et
 

--- a/include/driver.inc
+++ b/include/driver.inc
@@ -41,17 +41,56 @@ drv_\name:
 
 ; API version 0
 #define SCREEN_VERSION     0 /* exit: A contains API version */
+
+; Returns the current screen size.
+
 #define SCREEN_GETSIZE     1 /* exit: A=width-1, X=height-1 */
-#define SCREEN_CLEAR       2 /* also homes cursor */
-#define SCREEN_SETCURSOR   3 /* entry: A=x, X=y; out of bounds undefined */
+
+; Clears the screen. The cursor position is left undefined.
+
+#define SCREEN_CLEAR       2
+
+; Sets the cursor position. Out of bounds coordinates produces undefined
+; behaviour.
+
+#define SCREEN_SETCURSOR   3 /* entry: A=x, X=y */
+
+; Gets the cursor position.
+
 #define SCREEN_GETCURSOR   4 /* exit: A=x, X=y */
-#define SCREEN_PUTCHAR     5 /* entry: A=char; moves cursor to right, unless at edge of screen */
-#define SCREEN_PUTSTRING   6 /* entry: XA=nul terminated pointer; as above */
-#define SCREEN_GETCHAR     7 /* entry: XA=timeoutin cs, exit: A=char, or C if timed out */
+
+; Writes a single printable character. Behaviour on writing non-printable
+; characters is undefined. The cursor is moved one space to the right; if the
+; cursor hits the edge of the screen, the behaviour is undefined.
+
+#define SCREEN_PUTCHAR     5 /* entry: A=char */
+
+; Writes a sequence of characters, equivalent to repeated calls to
+; SCREEN_PUTCHAR (but hopefully a lot faster).
+
+#define SCREEN_PUTSTRING   6 /* entry: XA=nul terminated pointer */
+
+; Blocks and waits for a input character. XA contains a timeout in
+; centiseconds.  This call may return early.
+
+#define SCREEN_GETCHAR     7 /* entry: XA=timeout in cs, exit: A=char, or C if timed out */
+
+; Sets whether the cursor is displayed or not.
+
 #define SCREEN_SHOWCURSOR  8 /* entry: A=0 for off, non-zero for on */
-#define SCREEN_SCROLLUP    9 /* cursor position left undefined */
-#define SCREEN_SCROLLDOWN 10 /* cursor position left undefined */
-#define SCREEN_CLEARTOEOL 11 /* from cursor position to EOL */
+
+; Scrolls the screen up by one line. The cursor position is left undefined.
+
+#define SCREEN_SCROLLUP    9
+
+; Scrolls the screen down by one line. The cursor position is left undefined.
+
+#define SCREEN_SCROLLDOWN 10
+
+; Clears from the current cursor position to the end of line. The cursor
+; position is left undefined.
+
+#define SCREEN_CLEARTOEOL 11
 
 ; vim: filetype=asm sw=4 ts=4 et
 

--- a/include/driver.inc
+++ b/include/driver.inc
@@ -71,7 +71,10 @@ drv_\name:
 #define SCREEN_PUTSTRING   6 /* entry: XA=nul terminated pointer */
 
 ; Blocks and waits for a input character. XA contains a timeout in
-; centiseconds.  This call may return early.
+; centiseconds. This call may return early.
+; ESCAPE returns 27.
+; DELETE returns 127 (not 8!).
+; Control+Letter returns the usual codes from 1 to 26.
 
 #define SCREEN_GETCHAR     7 /* entry: XA=timeout in cs, exit: A=char, or C if timed out */
 

--- a/include/jumptables.inc
+++ b/include/jumptables.inc
@@ -20,5 +20,13 @@
     .byte (\value - 1)@mos16hi
 .endm
 
+.macro jmptabloconst value
+    .byte (\value - 1) & 0xff
+.endm
+
+.macro jmptabhiconst value
+    .byte (\value - 1) >> 8
+.endm
+
 ; vim: filetype=asm sw=4 ts=4 et
 

--- a/include/jumptables.inc
+++ b/include/jumptables.inc
@@ -1,0 +1,24 @@
+; CP/M-65 Copyright © 2023 David Given
+; This file is licensed under the terms of the 2-clause BSD license. Please
+; see the COPYING file in the root project directory for the full text.
+
+.macro jmpdispatch lotab, hitab
+    sta ptr
+    lda \hitab, y
+    pha
+    lda \lotab, y
+    pha
+    lda ptr
+    rts
+.endm
+
+.macro jmptablo value
+    .byte (\value - 1)@mos16lo
+.endm
+
+.macro jmptabhi value
+    .byte (\value - 1)@mos16hi
+.endm
+
+; vim: filetype=asm sw=4 ts=4 et
+

--- a/lib/screen.S
+++ b/lib/screen.S
@@ -58,11 +58,6 @@ zproc screen_clear_to_eol, .text.screen_clear_to_eol
 	jmp _call_screen
 zendproc
 
-zproc screen_newline, .text.screen_newline
-	ldy #SCREEN_NEWLINE
-	jmp _call_screen
-zendproc
-
 zproc screen_waitchar, .text.waitchar
 	zrepeat
 		lda #0xff

--- a/lib/screen.S
+++ b/lib/screen.S
@@ -58,7 +58,7 @@ zproc screen_clear_to_eol, .text.screen_clear_to_eol
 	jmp _call_screen
 zendproc
 
-zproc screen_waitchar, .text.waitchar
+zproc screen_waitchar, .text.screen_waitchar
 	zrepeat
 		lda #0xff
 		ldx #0x7f
@@ -68,3 +68,7 @@ zproc screen_waitchar, .text.waitchar
 	rts
 zendproc
 
+zproc screen_setstyle, .text.screen_setstyle
+	ldy #SCREEN_SETSTYLE
+	jmp _call_screen
+zendproc

--- a/lib/screen.h
+++ b/lib/screen.h
@@ -12,6 +12,7 @@ extern void screen_putstring(const char* s);
 extern uint16_t screen_getchar(uint16_t timeout_cs);
 extern uint8_t screen_waitchar(void);
 extern void screen_clear_to_eol(void);
+extern void screen_setstyle(uint8_t style);
 
 #define screen_setcursor(x, y) \
 	_screen_setcursor((x) | ((y)<<8))

--- a/lib/screen.h
+++ b/lib/screen.h
@@ -8,7 +8,6 @@ extern uint16_t _screen_getsize(void);
 extern void _screen_setcursor(uint16_t c);
 extern uint16_t _screen_getcursor(void);
 extern void screen_putchar(char c);
-extern void screen_newline(void);
 extern void screen_putstring(const char* s);
 extern uint16_t screen_getchar(uint16_t timeout_cs);
 extern uint8_t screen_waitchar(void);

--- a/src/bdos.S
+++ b/src/bdos.S
@@ -935,6 +935,7 @@ zproc entry_DELETEFILE
             lda #FCB_T3+1
             jsr find_next
         zuntil_cs
+        clc
     zendif
 
     rts
@@ -980,6 +981,7 @@ zproc entry_RENAMEFILE
             lda #FCB_T3+1
             jsr find_next
         zuntil_cs
+        clc
     zendif
 
     rts
@@ -1015,6 +1017,7 @@ zproc entry_SETFILEATTRS
             lda #FCB_T3+1
             jsr find_next
         zuntil_cs
+        clc
     zendif
 
     rts

--- a/src/bios/bbcmicro.S
+++ b/src/bios/bbcmicro.S
@@ -53,6 +53,13 @@ zproc _start
 
     ; Load the BDOS image.
 
+    ldy #0x11
+    lda #0
+    zrepeat
+        sta bdos_osfile_block, y
+        dey
+    zuntil_mi
+
     lda #<bdos_filename
     sta bdos_osfile_block + 0
     lda #>bdos_filename
@@ -161,8 +168,6 @@ screen_jmptable_lo:
     .byte screen_scrollup@mos16lo
     .byte screen_scrolldown@mos16lo
     .byte screen_cleartoeol@mos16lo
-    .byte OSNEWL@mos16lo
-    .byte screen_backspace@mos16lo
 screen_jmptable_hi:
     .byte screen_version@mos16hi
     .byte screen_getsize@mos16hi
@@ -176,8 +181,6 @@ screen_jmptable_hi:
     .byte screen_scrollup@mos16hi
     .byte screen_scrolldown@mos16hi
     .byte screen_cleartoeol@mos16hi
-    .byte OSNEWL@mos16hi
-    .byte screen_backspace@mos16hi
 zendproc
 
 zproc set_cursor_keys
@@ -203,6 +206,7 @@ zendproc
 
 zproc screen_clear
     lda #12             ; clear screen
+oswrch:
     jmp OSWRCH
 zendproc
 
@@ -247,14 +251,11 @@ zendproc
 
 zproc screen_putchar
     cmp #32
-    zif_cc
-        rts
-    zendif
-    cmp #127
     zif_cs
-        rts
+        cmp #127
+        bcc oswrch
     zendif
-    jmp OSWRCH
+    rts
 zendproc
 
 zproc screen_putstring
@@ -276,14 +277,14 @@ zproc screen_scrollup
     lda #0
     jsr screen_setcursor
     lda #10
-    jmp OSWRCH
+    bne oswrch          ; always taken
 zendproc
 
 zproc screen_scrolldown
     lda #30             ; home
     jsr OSWRCH
     lda #11             ; cursor up
-    jmp OSWRCH
+    bne oswrch          ; always taken
 zendproc
 
 zproc screen_cleartoeol
@@ -311,11 +312,6 @@ zproc screen_cleartoeol
     jmp screen_setcursor
 zendproc
 
-zproc screen_backspace
-    lda #127
-    jmp OSWRCH
-zendproc
-
 ; --- TTY driver ------------------------------------------------------------
 
 defdriver TTY, DRVID_TTY, drvstrat_TTY, drv_SCREEN
@@ -323,22 +319,22 @@ defdriver TTY, DRVID_TTY, drvstrat_TTY, drv_SCREEN
 ; TTY driver strategy routine.
 ; Y=TTY opcode.
 zproc drvstrat_TTY
+    sta ptr
+    lda jmptable_hi, y
     pha
     lda jmptable_lo, y
-    sta ptr+0
-    lda jmptable_hi, y
-    sta ptr+1
-    pla
-    jmp (ptr)
+    pha
+    lda ptr
+    rts
 
 jmptable_lo:
-    .byte tty_const@mos16lo
-    .byte tty_conin@mos16lo
-    .byte OSWRCH@mos16lo
+    .byte (tty_const-1)@mos16lo
+    .byte (tty_conin-1)@mos16lo
+    .byte (OSWRCH-1) & 0xff
 jmptable_hi:
-    .byte tty_const@mos16hi
-    .byte tty_conin@mos16hi
-    .byte OSWRCH@mos16hi
+    .byte (tty_const-1)@mos16hi
+    .byte (tty_conin-1)@mos16hi
+    .byte (OSWRCH-1) >> 8
 zendproc
 
 ; Blocks and waits for the next keypress; returns it in A.

--- a/src/bios/bbcmicro.S
+++ b/src/bios/bbcmicro.S
@@ -152,6 +152,7 @@ screen_jmptable_lo:
     jmptablo screen_scrollup
     jmptablo screen_scrolldown
     jmptablo screen_cleartoeol
+    jmptablo fail
 screen_jmptable_hi:
     jmptabhi screen_version
     jmptabhi screen_getsize
@@ -165,6 +166,7 @@ screen_jmptable_hi:
     jmptabhi screen_scrollup
     jmptabhi screen_scrolldown
     jmptabhi screen_cleartoeol
+    jmptabhi fail
 zendproc
 
 zproc set_cursor_keys

--- a/src/bios/bbcmicro.S
+++ b/src/bios/bbcmicro.S
@@ -152,7 +152,7 @@ screen_jmptable_lo:
     jmptablo screen_scrollup
     jmptablo screen_scrolldown
     jmptablo screen_cleartoeol
-    jmptablo fail
+    jmptablo screen_setstyle
 screen_jmptable_hi:
     jmptabhi screen_version
     jmptabhi screen_getsize
@@ -166,7 +166,7 @@ screen_jmptable_hi:
     jmptabhi screen_scrollup
     jmptabhi screen_scrolldown
     jmptabhi screen_cleartoeol
-    jmptabhi fail
+    jmptabhi screen_setstyle
 zendproc
 
 zproc set_cursor_keys
@@ -296,6 +296,29 @@ zproc screen_cleartoeol
     lda ptr+0
     ldx ptr+1
     jmp screen_setcursor
+zendproc
+
+zproc setcolour
+    pha
+    lda #17
+    jsr OSWRCH
+    pla
+    jmp OSWRCH
+zendproc
+
+zproc screen_setstyle
+    and #STYLE_REVERSE
+
+    zif_eq
+        lda #7              ; white foreground
+        jsr setcolour
+        lda #128            ; black background
+        jmp setcolour
+    zendif
+    lda #0              ; black foreground
+    jsr setcolour
+    lda #135            ; white background
+    jmp setcolour
 zendproc
 
 ; --- TTY driver ------------------------------------------------------------

--- a/src/bios/bbcmicro.S
+++ b/src/bios/bbcmicro.S
@@ -6,6 +6,7 @@
 #include "mos.inc"
 #include "cpm65.inc"
 #include "driver.inc"
+#include "jumptables.inc"
 
 ZEROPAGE
 
@@ -143,40 +144,34 @@ defdriver SCREEN, DRVID_SCREEN, drvstrat_SCREEN, 0
 ; SCREEN driver strategy routine.
 ; Y=SCREEN opcode.
 zproc drvstrat_SCREEN
-    pha
-    lda screen_jmptable_lo, y
-    sta ptr+0
-    lda screen_jmptable_hi, y
-    sta ptr+1
-    pla
-    jmp (ptr)
+    jmpdispatch screen_jmptable_lo, screen_jmptable_hi
 
 screen_jmptable_lo:
-    .byte screen_version@mos16lo
-    .byte screen_getsize@mos16lo
-    .byte screen_clear@mos16lo
-    .byte screen_setcursor@mos16lo
-    .byte screen_getcursor@mos16lo
-    .byte screen_putchar@mos16lo
-    .byte screen_putstring@mos16lo
-    .byte screen_getchar@mos16lo
-    .byte fail@mos16lo
-    .byte screen_scrollup@mos16lo
-    .byte screen_scrolldown@mos16lo
-    .byte screen_cleartoeol@mos16lo
+    jmptablo screen_version
+    jmptablo screen_getsize
+    jmptablo screen_clear
+    jmptablo screen_setcursor
+    jmptablo screen_getcursor
+    jmptablo screen_putchar
+    jmptablo screen_putstring
+    jmptablo screen_getchar
+    jmptablo fail
+    jmptablo screen_scrollup
+    jmptablo screen_scrolldown
+    jmptablo screen_cleartoeol
 screen_jmptable_hi:
-    .byte screen_version@mos16hi
-    .byte screen_getsize@mos16hi
-    .byte screen_clear@mos16hi
-    .byte screen_setcursor@mos16hi
-    .byte screen_getcursor@mos16hi
-    .byte screen_putchar@mos16hi
-    .byte screen_putstring@mos16hi
-    .byte screen_getchar@mos16hi
-    .byte fail@mos16hi
-    .byte screen_scrollup@mos16hi
-    .byte screen_scrolldown@mos16hi
-    .byte screen_cleartoeol@mos16hi
+    jmptabhi screen_version
+    jmptabhi screen_getsize
+    jmptabhi screen_clear
+    jmptabhi screen_setcursor
+    jmptabhi screen_getcursor
+    jmptabhi screen_putchar
+    jmptabhi screen_putstring
+    jmptabhi screen_getchar
+    jmptabhi fail
+    jmptabhi screen_scrollup
+    jmptabhi screen_scrolldown
+    jmptabhi screen_cleartoeol
 zendproc
 
 zproc set_cursor_keys
@@ -315,22 +310,16 @@ defdriver TTY, DRVID_TTY, drvstrat_TTY, drv_SCREEN
 ; TTY driver strategy routine.
 ; Y=TTY opcode.
 zproc drvstrat_TTY
-    sta ptr
-    lda jmptable_hi, y
-    pha
-    lda jmptable_lo, y
-    pha
-    lda ptr
-    rts
+    jmpdispatch tty_jmptable_lo, tty_jmptable_hi
 
-jmptable_lo:
-    .byte (tty_const-1)@mos16lo
-    .byte (tty_conin-1)@mos16lo
-    .byte (OSWRCH-1) & 0xff
-jmptable_hi:
-    .byte (tty_const-1)@mos16hi
-    .byte (tty_conin-1)@mos16hi
-    .byte (OSWRCH-1) >> 8
+tty_jmptable_lo:
+    jmptablo tty_const
+    jmptablo tty_conin
+    .byte OSWRCH & 0xff
+tty_jmptable_hi:
+    jmptabhi tty_const
+    jmptabhi tty_conin
+    .byte OSWRCH >> 8
 zendproc
 
 ; Blocks and waits for the next keypress; returns it in A.

--- a/src/bios/bbcmicro.S
+++ b/src/bios/bbcmicro.S
@@ -49,13 +49,6 @@ zproc _start
 
     ; Load the BDOS image.
 
-    ldy #0x11
-    lda #0
-    zrepeat
-        sta bdos_osfile_block, y
-        dey
-    zuntil_mi
-
     lda mem_base
     sta bdos_osfile_block + 3
     lda #$ff
@@ -315,11 +308,11 @@ zproc drvstrat_TTY
 tty_jmptable_lo:
     jmptablo tty_const
     jmptablo tty_conin
-    .byte OSWRCH & 0xff
+    jmptabloconst OSWRCH
 tty_jmptable_hi:
     jmptabhi tty_const
     jmptabhi tty_conin
-    .byte OSWRCH >> 8
+    jmptabhiconst OSWRCH
 zendproc
 
 ; Blocks and waits for the next keypress; returns it in A.

--- a/src/bios/bbcmicro.S
+++ b/src/bios/bbcmicro.S
@@ -225,13 +225,6 @@ zproc screen_getchar
     lda #0x81           ; read key with timeout
     jsr OSBYTE
     txa
-    zif_cc
-        cmp #127
-        zif_eq
-            lda #8
-        zendif
-        clc
-    zendif
     rts
 zendproc
 

--- a/src/bios/bbcmicro.S
+++ b/src/bios/bbcmicro.S
@@ -528,8 +528,6 @@ pending_key: .byte 0    ; pending keypress from system
 dma:         .word 0    ; current DMA
 sector_num:  .fill 3    ; current absolute sector number
 
-ZEROPAGE
-
 osgbpb_block:           ; block used by entry_READ and entry_WRITE
     .fill $0d
 osgbpb_block_end:

--- a/src/bios/biosentry.S
+++ b/src/bios/biosentry.S
@@ -6,53 +6,48 @@
 #include "mos.inc"
 #include "cpm65.inc"
 #include "driver.inc"
+#include "jumptables.inc"
 
 .global drvtop
 
 ; BIOS entry point. Parameter is in XA, function in Y.
 zproc biosentry
-    pha
-    lda biostable_lo, y
-    sta ptr+0
-    lda biostable_hi, y
-    sta ptr+1
-    pla
-    jmp (ptr)
+	jmpdispatch biostable_lo, biostable_hi
 
 biostable_lo:
-    .byte entry_CONST@mos16lo
-    .byte entry_CONIN@mos16lo
-    .byte entry_CONOUT@mos16lo
-    .byte entry_SELDSK@mos16lo
-    .byte entry_SETSEC@mos16lo
-    .byte entry_SETDMA@mos16lo
-    .byte entry_READ@mos16lo
-    .byte entry_WRITE@mos16lo
-    .byte entry_RELOCATE@mos16lo
-    .byte entry_GETTPA@mos16lo
-    .byte entry_SETTPA@mos16lo
-    .byte entry_GETZP@mos16lo
-    .byte entry_SETZP@mos16lo
-    .byte entry_SETBANK@mos16lo
-	.byte entry_ADDDRV@mos16lo
-	.byte entry_FINDDRV@mos16lo
+    jmptablo entry_CONST
+    jmptablo entry_CONIN
+    jmptablo entry_CONOUT
+    jmptablo entry_SELDSK
+    jmptablo entry_SETSEC
+    jmptablo entry_SETDMA
+    jmptablo entry_READ
+    jmptablo entry_WRITE
+    jmptablo entry_RELOCATE
+    jmptablo entry_GETTPA
+    jmptablo entry_SETTPA
+    jmptablo entry_GETZP
+    jmptablo entry_SETZP
+    jmptablo entry_SETBANK
+	jmptablo entry_ADDDRV
+	jmptablo entry_FINDDRV
 biostable_hi:
-    .byte entry_CONST@mos16hi
-    .byte entry_CONIN@mos16hi
-    .byte entry_CONOUT@mos16hi
-    .byte entry_SELDSK@mos16hi
-    .byte entry_SETSEC@mos16hi
-    .byte entry_SETDMA@mos16hi
-    .byte entry_READ@mos16hi
-    .byte entry_WRITE@mos16hi
-    .byte entry_RELOCATE@mos16hi
-    .byte entry_GETTPA@mos16hi
-    .byte entry_SETTPA@mos16hi
-    .byte entry_GETZP@mos16hi
-    .byte entry_SETZP@mos16hi
-    .byte entry_SETBANK@mos16hi
-	.byte entry_ADDDRV@mos16hi
-	.byte entry_FINDDRV@mos16hi
+    jmptabhi entry_CONST
+    jmptabhi entry_CONIN
+    jmptabhi entry_CONOUT
+    jmptabhi entry_SELDSK
+    jmptabhi entry_SETSEC
+    jmptabhi entry_SETDMA
+    jmptabhi entry_READ
+    jmptabhi entry_WRITE
+    jmptabhi entry_RELOCATE
+    jmptabhi entry_GETTPA
+    jmptabhi entry_SETTPA
+    jmptabhi entry_GETZP
+    jmptabhi entry_SETZP
+    jmptabhi entry_SETBANK
+	jmptabhi entry_ADDDRV
+	jmptabhi entry_FINDDRV
 zendproc
 
 zproc entry_ADDDRV

--- a/src/bios/biosentry.S
+++ b/src/bios/biosentry.S
@@ -10,6 +10,9 @@
 
 .global drvtop
 
+.zeropage ptr
+.zeropage ptr1
+
 ; BIOS entry point. Parameter is in XA, function in Y.
 zproc biosentry
 	jmpdispatch biostable_lo, biostable_hi

--- a/src/bios/commodore/ieee488.S
+++ b/src/bios/commodore/ieee488.S
@@ -7,6 +7,9 @@
 
 ZEROPAGE
 
+.zeropage ptr
+.zeropage ptr1
+
 ieee_has_buffered_char: .fill 1
 ieee_buffered_char:     .fill 1
 

--- a/src/bios/pet.S
+++ b/src/bios/pet.S
@@ -5,6 +5,7 @@
 #include "zif.inc"
 #include "cpm65.inc"
 #include "driver.inc"
+#include "jumptables.inc"
 
 PIA1    = 0xe810
 PIA1_PA = PIA1 + 0
@@ -297,40 +298,34 @@ defdriver SCREEN, DRVID_SCREEN, drvstrat_SCREEN, 0
 ; SCREEN driver strategy routine.
 ; Y=SCREEN opcode.
 zproc drvstrat_SCREEN
-    pha
-    lda screen_jmptable_lo, y
-    sta ptr+0
-    lda screen_jmptable_hi, y
-    sta ptr+1
-    pla
-    jmp (ptr)
+    jmpdispatch screen_jmptable_lo, screen_jmptable_hi
 
 screen_jmptable_lo:
-    .byte screen_version@mos16lo
-    .byte screen_getsize@mos16lo
-    .byte screen_clear@mos16lo
-    .byte screen_setcursor@mos16lo
-    .byte screen_getcursor@mos16lo
-    .byte screen_putchar@mos16lo
-    .byte screen_putstring@mos16lo
-    .byte screen_getchar@mos16lo
-    .byte fail@mos16lo
-    .byte screen_scrollup@mos16lo
-    .byte screen_scrolldown@mos16lo
-    .byte screen_cleartoeol@mos16lo
+    jmptablo screen_version
+    jmptablo screen_getsize
+    jmptablo screen_clear
+    jmptablo screen_setcursor
+    jmptablo screen_getcursor
+    jmptablo screen_putchar
+    jmptablo screen_putstring
+    jmptablo screen_getchar
+    jmptablo fail
+    jmptablo screen_scrollup
+    jmptablo screen_scrolldown
+    jmptablo screen_cleartoeol
 screen_jmptable_hi:
-    .byte screen_version@mos16hi
-    .byte screen_getsize@mos16hi
-    .byte screen_clear@mos16hi
-    .byte screen_setcursor@mos16hi
-    .byte screen_getcursor@mos16hi
-    .byte screen_putchar@mos16hi
-    .byte screen_putstring@mos16hi
-    .byte screen_getchar@mos16hi
-    .byte fail@mos16hi
-    .byte screen_scrollup@mos16hi
-    .byte screen_scrolldown@mos16hi
-    .byte screen_cleartoeol@mos16hi
+    jmptabhi screen_version
+    jmptabhi screen_getsize
+    jmptabhi screen_clear
+    jmptabhi screen_setcursor
+    jmptabhi screen_getcursor
+    jmptabhi screen_putchar
+    jmptabhi screen_putstring
+    jmptabhi screen_getchar
+    jmptabhi fail
+    jmptabhi screen_scrollup
+    jmptabhi screen_scrolldown
+    jmptabhi screen_cleartoeol
 zendproc
 
 zproc fail
@@ -539,22 +534,16 @@ defdriver TTY, DRVID_TTY, drvstrat_TTY, drv_SCREEN
 ; TTY driver strategy routine.
 ; Y=TTY opcode.
 zproc drvstrat_TTY
-    pha
-    lda jmptable_lo, y
-    sta ptr+0
-    lda jmptable_hi, y
-    sta ptr+1
-    pla
-    jmp (ptr)
+    jmpdispatch jmptable_lo, jmptable_hi
 
 jmptable_lo:
-    .byte tty_const@mos16lo
-    .byte tty_conin@mos16lo
-    .byte tty_conout@mos16lo
+    jmptablo tty_const
+    jmptablo tty_conin
+    jmptablo tty_conout
 jmptable_hi:
-    .byte tty_const@mos16hi
-    .byte tty_conin@mos16hi
-    .byte tty_conout@mos16hi
+    jmptabhi tty_const
+    jmptabhi tty_conin
+    jmptabhi tty_conout
 zendproc
 
 ; Returns 0xff if no key is pending, 0 if one is.

--- a/src/bios/pet.S
+++ b/src/bios/pet.S
@@ -313,6 +313,7 @@ screen_jmptable_lo:
     jmptablo screen_scrollup
     jmptablo screen_scrolldown
     jmptablo screen_cleartoeol
+    jmptablo fail
 screen_jmptable_hi:
     jmptabhi screen_version
     jmptabhi screen_getsize
@@ -326,6 +327,7 @@ screen_jmptable_hi:
     jmptabhi screen_scrollup
     jmptabhi screen_scrolldown
     jmptabhi screen_cleartoeol
+    jmptabhi fail
 zendproc
 
 zproc fail

--- a/src/bios/relocate.S
+++ b/src/bios/relocate.S
@@ -5,6 +5,8 @@
 #include "cpm65.inc"
 #include "zif.inc"
 
+.zeropage ptr
+
 ; Relocate an image. High byte of memory address is in A,
 ; zero page address is in X.
 


### PR DESCRIPTION
There's a lot more undefined behaviour now, which should make it much easier to implement on a variety of systems --- scrolling and wrapping is explicit. There's also a new style command.

This adds a PET driver and reworks the BBC Micro driver, plus lots of other bugfixes and enhancements across the board.