### PR TITLE
load BDOS from CP/M filesystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,9 +306,10 @@ atari800.atr: $(OBJDIR)/atari800.exe $(OBJDIR)/bdos.img Makefile \
 	dd if=/dev/zero of=$@ bs=128 count=720
 	mkfs.cpm -f atari90 $@
 	cp $(OBJDIR)/a8setfnt.com $(OBJDIR)/setfnt.com
+	cpmcp -f atari90 $@ $(OBJDIR)/bdos.img 0:bdos.sys
 	cpmcp -f atari90 $@ $(OBJDIR)/ccp.sys $(MINIMAL_APPS) $(SCREEN_APPS) 0:
 	cpmcp -f atari90 $@ $(OBJDIR)/apps/ls.com $(OBJDIR)/setfnt.com third_party/fonts/atari/olivetti.fnt 1:
-	cpmchattr -f atari90 $@ sr 0:ccp.sys
+	cpmchattr -f atari90 $@ sr 0:bdos.sys 0:ccp.sys
 	dd if=$(OBJDIR)/atari800.exe of=$@ bs=128 conv=notrunc
 	dd if=$(OBJDIR)/bdos.img of=$@ bs=128 seek=10 conv=notrunc
 	mv $@ $@.raw
@@ -324,9 +325,10 @@ atari800hd.atr: $(OBJDIR)/atari800hd.exe $(OBJDIR)/bdos.img Makefile \
 	dd if=/dev/zero of=$@ bs=128 count=8190
 	mkfs.cpm -f atarihd $@
 	cp $(OBJDIR)/a8setfnt.com $(OBJDIR)/setfnt.com
+	cpmcp -f atarihd $@ $(OBJDIR)/bdos.img 0:bdos.sys
 	cpmcp -f atarihd $@ $(OBJDIR)/ccp.sys $(APPS) $(SCREEN_APPS) 0:
 	cpmcp -f atarihd $@ $(OBJDIR)/apps/ls.com $(OBJDIR)/setfnt.com third_party/fonts/atari/*.fnt 1:
-	cpmchattr -f atarihd $@ sr 0:ccp.sys
+	cpmchattr -f atarihd $@ sr 0:bdos.sys 0:ccp.sys
 	dd if=$(OBJDIR)/atari800hd.exe of=$@ bs=128 conv=notrunc
 	dd if=$(OBJDIR)/bdos.img of=$@ bs=128 seek=10 conv=notrunc
 	mv $@ $@.raw

--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,6 @@ atari800.atr: $(OBJDIR)/atari800.exe $(OBJDIR)/bdos.img Makefile \
 	cpmcp -f atari90 $@ $(OBJDIR)/apps/ls.com $(OBJDIR)/setfnt.com third_party/fonts/atari/olivetti.fnt 1:
 	cpmchattr -f atari90 $@ sr 0:bdos.sys 0:ccp.sys
 	dd if=$(OBJDIR)/atari800.exe of=$@ bs=128 conv=notrunc
-	dd if=$(OBJDIR)/bdos.img of=$@ bs=128 seek=10 conv=notrunc
 	mv $@ $@.raw
 	/usr/bin/printf '\x96\x02\x80\x16\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' > $@
 	cat $@.raw >> $@
@@ -330,7 +329,6 @@ atari800hd.atr: $(OBJDIR)/atari800hd.exe $(OBJDIR)/bdos.img Makefile \
 	cpmcp -f atarihd $@ $(OBJDIR)/apps/ls.com $(OBJDIR)/setfnt.com third_party/fonts/atari/*.fnt 1:
 	cpmchattr -f atarihd $@ sr 0:bdos.sys 0:ccp.sys
 	dd if=$(OBJDIR)/atari800hd.exe of=$@ bs=128 conv=notrunc
-	dd if=$(OBJDIR)/bdos.img of=$@ bs=128 seek=10 conv=notrunc
 	mv $@ $@.raw
 	/usr/bin/printf '\x96\x02\xf0\xff\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' > $@
 	cat $@.raw >> $@

--- a/diskdefs
+++ b/diskdefs
@@ -60,7 +60,7 @@ diskdef atari90
     sectrk 18
     blocksize 1024
     maxdir 64
-    boottrk 3
+    boottrk 1
     os 2.2
 end
 
@@ -73,7 +73,7 @@ diskdef atarihd
     sectrk 18
     blocksize 2048
     maxdir 128
-    boottrk 3
+    boottrk 1
     os 2.2
 end
 

--- a/include/atari800.inc
+++ b/include/atari800.inc
@@ -5,7 +5,10 @@ FMSZPG = $43    ; FMS zero page, but we don't use Atari DOS.SYS (7 bytes)
 
 MEMTOP = $02e5
 
+COLPF2 = $d018
 DMACTL = $d400
+DLISTL = $d402
+DLISTH = $d403
 
 CIOV = $e456
 

--- a/scripts/atari800.ld
+++ b/scripts/atari800.ld
@@ -18,7 +18,6 @@ SECTIONS {
 		*(.noinit .noinit.*)
 		. = ALIGN(256);
 		__USERTPA_START__ = .;
-		__USERTPA_END__ = 0xbc00;
 	} >ram
 }
 

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -49,9 +49,9 @@ _start:
 
     .byte 0
 #ifdef ATARI_HD
-    .byte 10 + 30  ; 8 + 28 (BIOS+BDOS) (BIOS must be multiple of 2, one page)
+    .byte 10
 #else
-    .byte 10 + 30  ; 8 + 28 (BIOS+BDOS) (BIOS must be multiple of 2, one page)
+    .byte 10
 #endif
     .word $0500
     .word init      ; just use init and never return
@@ -68,6 +68,7 @@ init:
     sta COLCRS+1
     sta SHFLOK      ; start lower case
     sta COLOR2      ; background (black)
+    sta COLPF2      ; hardware register, too, VBI might not occur during SIO
 ;    stx COLOR1      ; foreground a tad brighter (luma only)
 
     ; IOCB0 E: is already open
@@ -84,7 +85,9 @@ init:
     sta SDMCTL      ; turn off screen gracefully while we adjust the DL
     sta DMACTL      ; hardware register, too, VBI might not occur during SIO
     sta SDLSTL      ; set DL pointer to MEMTOP+1
+    sta DLISTL      ; hardware registers, too
     stx SDLSTL+1
+    stx DLISTH
     tay
 
     stx dl_prologue+4
@@ -120,6 +123,7 @@ init:
 
     lda #$22
     sta SDMCTL      ; turn on screen again
+    sta DMACTL      ; and hardware register, too
 
     ; Print banner.
 
@@ -156,7 +160,8 @@ init:
     jsr initdrivers
 
     ; Load the BDOS image to mem_base
-    ; BDOS is already loaded at mem_base by the Atari OS bootloader
+
+    jsr load_bdos
 
     ; Relocate it.
 
@@ -758,6 +763,56 @@ zendproc
 
 ; ---------------------------------------------------------------------------
 
+DIRSECT  = RESERVED
+BDOSSECT = DIRSECT + (DIRENTRIES*32)/128
+DIRE_RC  = 15
+
+zproc load_bdos
+    lda #0
+    jsr entry_SELDSK
+
+    lda #<__USERTPA_START__
+    ldx #>__USERTPA_START__
+    jsr entry_SETDMA
+
+    lda #<DIRSECT
+    sta sector_num
+    lda #>DIRSECT
+    sta sector_num+1
+
+    jsr entry_READ
+
+    lda #<BDOSSECT
+    sta sector_num
+    lda #>BDOSSECT
+    sta sector_num+1
+
+    ldx __USERTPA_START__ + DIRE_RC
+
+    zrepeat
+        stx save_x
+        jsr entry_READ
+
+        lda dma
+        clc
+        adc #128
+        sta dma
+        zif_cs
+            inc dma+1
+        zendif
+        inc sector_num
+        zif_eq
+            inc sector_num+1
+        zendif
+        ldx save_x
+        dex
+    zuntil_eq
+
+    rts
+zendproc
+
+; ---------------------------------------------------------------------------
+
     .data
 zp_base: .byte __USERZEROPAGE_START__
 zp_end:  .byte __USERZEROPAGE_END__
@@ -772,10 +827,18 @@ mem_end:  .byte __USERTPA_END__@mos16hi
 ; 54 reserved sectors = 6912 bytes for BIOS and BDOS
 
 #ifdef ATARI_HD
-define_drive dph, 8190, 2048, 128, 54
+NUMSECTORS = 8190
+BLOCKSIZE  = 2048
+DIRENTRIES = 128
+RESERVED    = 54
 #else
-define_drive dph, 720, 1024, 64, 54
+NUMSECTORS = 720
+BLOCKSIZE  = 1024
+DIRENTRIES = 64
+RESERVED   = 54
 #endif
+
+define_drive dph, NUMSECTORS, BLOCKSIZE, DIRENTRIES, RESERVED
 
 NOINIT
 

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -818,7 +818,7 @@ zp_base: .byte __USERZEROPAGE_START__
 zp_end:  .byte __USERZEROPAGE_END__
 
 mem_base: .byte __USERTPA_START__@mos16hi
-mem_end:  .byte __USERTPA_END__@mos16hi
+mem_end:  .byte 0
 
 ; DPH for drive 0 (our only drive)
 

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -824,18 +824,16 @@ mem_end:  .byte 0
 
 ; number of sectors, blocksize, direntries, reserved _sectors_
 
-; 54 reserved sectors = 6912 bytes for BIOS and BDOS
-
 #ifdef ATARI_HD
 NUMSECTORS = 8190
 BLOCKSIZE  = 2048
 DIRENTRIES = 128
-RESERVED    = 54
+RESERVED    = 18
 #else
 NUMSECTORS = 720
 BLOCKSIZE  = 1024
 DIRENTRIES = 64
-RESERVED   = 54
+RESERVED   = 18
 #endif
 
 define_drive dph, NUMSECTORS, BLOCKSIZE, DIRENTRIES, RESERVED


### PR DESCRIPTION
Loads BDOS.SYS from CP/M filesystem. Assumes BDOS.SYS is the first directory entry, follows right after the directory and occupies consecutive sectors.