### PR TITLE
Updated Atari port to new BDOS loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -301,11 +301,10 @@ atari800.atr: $(OBJDIR)/atari800.exe $(OBJDIR)/bdos.sys Makefile \
 	dd if=/dev/zero of=$@ bs=128 count=720
 	mkfs.cpm -f atari90 $@
 	cp $(OBJDIR)/a8setfnt.com $(OBJDIR)/setfnt.com
-	cpmcp -f atari90 $@ $(OBJDIR)/ccp.sys $(MINIMAL_APPS) $(SCREEN_APPS) 0:
+	cpmcp -f atari90 $@ $(OBJDIR)/bdos.sys $(OBJDIR)/ccp.sys $(MINIMAL_APPS) $(SCREEN_APPS) 0:
 	cpmcp -f atari90 $@ $(OBJDIR)/apps/ls.com $(OBJDIR)/setfnt.com third_party/fonts/atari/olivetti.fnt 1:
-	cpmchattr -f atari90 $@ sr 0:ccp.sys
+	cpmchattr -f atari90 $@ sr 0:ccp.sys o:bdos.sys
 	dd if=$(OBJDIR)/atari800.exe of=$@ bs=128 conv=notrunc
-	dd if=$(OBJDIR)/bdos.sys of=$@ bs=128 seek=10 conv=notrunc
 	mv $@ $@.raw
 	/usr/bin/printf '\x96\x02\x80\x16\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' > $@
 	cat $@.raw >> $@
@@ -319,11 +318,10 @@ atari800hd.atr: $(OBJDIR)/atari800hd.exe $(OBJDIR)/bdos.sys Makefile \
 	dd if=/dev/zero of=$@ bs=128 count=8190
 	mkfs.cpm -f atarihd $@
 	cp $(OBJDIR)/a8setfnt.com $(OBJDIR)/setfnt.com
-	cpmcp -f atarihd $@ $(OBJDIR)/ccp.sys $(APPS) $(SCREEN_APPS) 0:
+	cpmcp -f atarihd $@ $(OBJDIR)/bdos.sys $(OBJDIR)/ccp.sys $(APPS) $(SCREEN_APPS) 0:
 	cpmcp -f atarihd $@ $(OBJDIR)/apps/ls.com $(OBJDIR)/setfnt.com third_party/fonts/atari/*.fnt 1:
-	cpmchattr -f atarihd $@ sr 0:ccp.sys
+	cpmchattr -f atarihd $@ sr 0:ccp.sys 0:bdos.sys
 	dd if=$(OBJDIR)/atari800hd.exe of=$@ bs=128 conv=notrunc
-	dd if=$(OBJDIR)/bdos.sys of=$@ bs=128 seek=10 conv=notrunc
 	mv $@ $@.raw
 	/usr/bin/printf '\x96\x02\xf0\xff\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' > $@
 	cat $@.raw >> $@

--- a/diskdefs
+++ b/diskdefs
@@ -60,7 +60,7 @@ diskdef atari90
     sectrk 18
     blocksize 1024
     maxdir 64
-    boottrk 3
+    boottrk 1
     os 2.2
 end
 
@@ -73,7 +73,7 @@ diskdef atarihd
     sectrk 18
     blocksize 2048
     maxdir 128
-    boottrk 3
+    boottrk 1
     os 2.2
 end
 

--- a/include/atari800.inc
+++ b/include/atari800.inc
@@ -5,7 +5,11 @@ FMSZPG = $43    ; FMS zero page, but we don't use Atari DOS.SYS (7 bytes)
 
 MEMTOP = $02e5
 
+COLPF2 = $d018
+
 DMACTL = $d400
+DLISTL = $d402
+DLISTH = $d403
 
 CIOV = $e456
 

--- a/include/atari800.inc
+++ b/include/atari800.inc
@@ -3,8 +3,6 @@
 PTEMP  = $1f    ; P: handler temporary we can use freely, unless we print
 FMSZPG = $43    ; FMS zero page, but we don't use Atari DOS.SYS (7 bytes)
 
-MEMTOP = $02e5
-
 COLPF2 = $d018
 
 DMACTL = $d400
@@ -16,6 +14,8 @@ CIOV = $e456
 SDMCTL = $022f
 SDLSTL = $0230
 SHFLOK = $02be
+CH     = $02fc
+MEMTOP = $02e5
 
 ICHID = $0340
 ICDNO = $0341

--- a/scripts/atari800.ld
+++ b/scripts/atari800.ld
@@ -1,6 +1,7 @@
 MEMORY {
     zp : ORIGIN = 0x80, LENGTH = 0x7f
     ram (rw) : ORIGIN = 0x500, LENGTH = 0x800
+    midram(rw) : ORIGIN = 0x3000, LENGTH = 0x800
 }
 
 SECTIONS {
@@ -13,19 +14,30 @@ SECTIONS {
         *(.loaderzp)
 	} >zp
 
+    .loader : {
+        *(loader)
+        *loader.o(.text .text.*)
+    } >midram
+
 	.text : {
+        bios_exec_addr = .;
+        bios_load_addr = LOADADDR(.text);
 		*(.text .text.*)
-	} >ram
-	.data : { *(.data .data.* .rodata .rodata.*) } > ram
+	} >ram AT>midram
+
+	.data : {
+        *(.data .data.* .rodata .rodata.*)
+        bios_end_addr = .;
+    } >ram AT>midram
+
 	.noinit (NOLOAD) : {
 		*(.noinit .noinit.*)
 		. = ALIGN(256);
 		__USERTPA_START__ = .;
-		__USERTPA_END__ = 0xbc00;
 	} >ram
 }
 
 OUTPUT_FORMAT {
-	TRIM(ram)
+	TRIM(midram)
 }
 

--- a/scripts/atari800.ld
+++ b/scripts/atari800.ld
@@ -8,6 +8,9 @@ SECTIONS {
 		*(.zp .zp.*)
 		__USERZEROPAGE_START__ = .;
 		__USERZEROPAGE_END__ = 0xff;
+
+        . = 0xf0;
+        *(.loaderzp)
 	} >zp
 
 	.text : {

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -43,6 +43,9 @@ cursory = ROWCRS
 ; by the directory buffer/
 
 .global _start
+
+.section loader, "ax"
+
 _start:
 
     ; Boot sector
@@ -53,10 +56,37 @@ _start:
 #else
     .byte 12
 #endif
-    .word $0500
+    .word $3000
     .word init      ; just use init and never return
 
 init:
+
+    ; Copy BIOS to low RAM
+
+    zrepeat
+        load1 = .
+        lda bios_load_addr
+        store1 = .
+        sta bios_exec_addr
+
+        inc load1+1
+        zif_eq
+            inc load1+2
+        zendif
+
+        inc store1+1
+        zif_eq
+            inc store1+2
+            zbreakif_eq
+        zendif
+
+        lda store1+1
+        cmp #<bios_end_addr
+        zcontinueif_ne
+        lda store1+2
+        cmp #>bios_end_addr
+    zuntil_eq
+
     ldx MEMTOP+1
     stx mem_end
     stx ptr+1
@@ -157,7 +187,13 @@ init:
 
     ; BIOS initialisation
 
-    jsr initdrivers
+;    jsr initdrivers
+
+    lda #<DRVID_TTY
+    ldx #>DRVID_TTY
+    jsr entry_FINDDRV
+    sta TTY+1
+    stx TTY+2
 
     ; Load the BDOS image to mem_base
 
@@ -182,43 +218,20 @@ init:
     lda #<biosentry
     ldx #>biosentry
     rts                 ; indirect jump to BDOS
-zendproc
-
-; Everything above here is overwritten by the directory buffer, so make sure
-; it's bigger than 0x80 bytes (currently: 0xa3).
-
-.global directory_buffer
-directory_buffer = _start
-
-; Below are 34 bytes that become available for overwrite during init. We use
-; them for variables afterwards.
-
-overwrite_after_display_stretch:        ; 5 bytes
 
 dl_prologue:
     .byte $70, $30, $42, 0, 0
-
-overwrite_after_banner:                 ; 27 bytes
 
 banner: ; reversed!
     .byte 10,13
     .ascii "008 iratA eht rof 56-M/PC"
 banner_end:
 
-overwrite_after_keyboard_init:          ; 2 bytes
-
 kdevice: .ascii "K"
          .byte 155
 
 bdos_filename:
     .ascii "BDOS    SYS"
-
-charin       = overwrite_after_display_stretch
-charout      = overwrite_after_display_stretch
-drive_number = overwrite_after_display_stretch + 1
-sector_num   = overwrite_after_display_stretch + 2 ; (and +3, and +4, full)
-
-dma          = overwrite_after_banner   ; (and +1
 
 ; --- BIOS entrypoints ------------------------------------------------------
 
@@ -771,11 +784,12 @@ zendproc
 ; ---------------------------------------------------------------------------
 
     .data
+
 zp_base: .byte __USERZEROPAGE_START__
 zp_end:  .byte __USERZEROPAGE_END__
 
 mem_base: .byte __USERTPA_START__@mos16hi
-mem_end:  .byte __USERTPA_END__@mos16hi
+mem_end:  .byte 0
 
 ; DPH for drive 0 (our only drive)
 
@@ -791,7 +805,12 @@ define_drive dph, 720, 1024, 64, 18
 
 NOINIT
 
-; Nothing left for .bss
+.global directory_buffer
+directory_buffer:   .fill 128
+charin:
+charout:            .fill 1
+drive_number:       .fill 1
+sector_num:         .fill 3
+dma:                .fill 2
 
 ; vim: filetype=asm sw=4 ts=4 et
-

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -68,6 +68,7 @@ init:
     sta COLCRS+1
     sta SHFLOK      ; start lower case
     sta COLOR2      ; background (black)
+    sta COLPF2      ; hardware register, too, VBI might not occur during SIO
 ;    stx COLOR1      ; foreground a tad brighter (luma only)
 
     ; IOCB0 E: is already open
@@ -82,9 +83,11 @@ init:
     ; proper 7x8 font from user space.
 
     sta SDMCTL      ; turn off screen gracefully while we adjust the DL
-    sta DMACTL      ; hardware register, too, VBI might not occur during SIO
+    sta DMACTL      ; hardware register
     sta SDLSTL      ; set DL pointer to MEMTOP+1
+    sta DLISTL
     stx SDLSTL+1
+    stx DLISTH
     tay
 
     stx dl_prologue+4
@@ -120,6 +123,7 @@ init:
 
     lda #$22
     sta SDMCTL      ; turn on screen again
+    sta DMACTL
 
     ; Print banner.
 

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -510,9 +510,16 @@ zproc tty_conin
     rts
 zendproc
 
+; Return 0 if no key is pending, $ff if there is
+
 zproc tty_const
-    lda #$00
-    clc
+    ldx CH
+    inx
+    zif_eq
+        lda #0
+        rts
+    zendif
+    lda #$ff
     rts
 zendproc
 

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -187,13 +187,7 @@ init:
 
     ; BIOS initialisation
 
-;    jsr initdrivers
-
-    lda #<DRVID_TTY
-    ldx #>DRVID_TTY
-    jsr entry_FINDDRV
-    sta TTY+1
-    stx TTY+2
+    jsr initdrivers
 
     ; Load the BDOS image to mem_base
 

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -49,9 +49,9 @@ _start:
 
     .byte 0
 #ifdef ATARI_HD
-    .byte 10 + 30  ; 8 + 28 (BIOS+BDOS) (BIOS must be multiple of 2, one page)
+    .byte 12
 #else
-    .byte 10 + 30  ; 8 + 28 (BIOS+BDOS) (BIOS must be multiple of 2, one page)
+    .byte 12
 #endif
     .word $0500
     .word init      ; just use init and never return
@@ -156,12 +156,16 @@ init:
     jsr initdrivers
 
     ; Load the BDOS image to mem_base
-    ; BDOS is already loaded at mem_base by the Atari OS bootloader
+
+    lda #<bdos_filename
+    ldx #>bdos_filename
+    ldy #>__USERTPA_START__
+    jsr loadfile
 
     ; Relocate it.
 
-    lda mem_base
-    ldx zp_base
+    lda #>__USERTPA_START__
+    ldx #__USERZEROPAGE_START__
     jsr entry_RELOCATE
 
     ; Compute the entry address and jump.
@@ -179,6 +183,7 @@ zendproc
 ; Everything above here is overwritten by the directory buffer, so make sure
 ; it's bigger than 0x80 bytes (currently: 0xa3).
 
+.global directory_buffer
 directory_buffer = _start
 
 ; Below are 34 bytes that become available for overwrite during init. We use
@@ -200,6 +205,9 @@ overwrite_after_keyboard_init:          ; 2 bytes
 
 kdevice: .ascii "K"
          .byte 155
+
+bdos_filename:
+    .ascii "BDOS    SYS"
 
 charin       = overwrite_after_display_stretch
 charout      = overwrite_after_display_stretch
@@ -772,9 +780,9 @@ mem_end:  .byte __USERTPA_END__@mos16hi
 ; 54 reserved sectors = 6912 bytes for BIOS and BDOS
 
 #ifdef ATARI_HD
-define_drive dph, 8190, 2048, 128, 54
+define_drive dph, 8190, 2048, 128, 18
 #else
-define_drive dph, 720, 1024, 64, 54
+define_drive dph, 720, 1024, 64, 18
 #endif
 
 NOINIT


### PR DESCRIPTION
Hi,

I deleted my bdos loader and updated to your new loader.

Reserved tracks went from 3 to 1. Boot block size increased to 12 sectors instead of 10 with my limited loader. Can't have it all I suppose ;)
