### PR TITLE
Set bank back to BANK_MAIN after call to FREE.

### DIFF
--- a/src/ccp.S
+++ b/src/ccp.S
@@ -491,6 +491,9 @@ zproc entry_FREE
     
     jsr printi
     .ascii ".\r\x8a"
+
+    lda #BANK_MAIN
+    jsr bios_SETBANK
     rts
 
 printsizes:


### PR DESCRIPTION
After FREE the bank was still set to BANK_EXTRA causing stat, qe, ls, etc.. not to work as expected.