### PR TITLE
Fix for make LLVM=<path>

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX = g++
 CC = gcc
 FPC = fpc
-LLVM = /opt/bin/
+LLVM ?= /opt/bin/
 
 CFLAGS = -O0 -g -I.
 CFLAGS65 = -Os -g -I. \
@@ -123,7 +123,7 @@ $(OBJDIR)/tools/%.o: tools/%.cc
 
 $(OBJDIR)/%.o: %.S include/zif.inc include/mos.inc include/cpm65.inc include/driver.inc
 	@mkdir -p $(dir $@)
-	mos-cpm65-clang $(CFLAGS65) -c -o $@ $< -I include
+	$(LLVM)mos-cpm65-clang $(CFLAGS65) -c -o $@ $< -I include
 
 $(OBJDIR)/third_party/altirrabasic/%.bin: \
 		$(wildcard third_party/altirrabasic/source/*.s) \
@@ -203,12 +203,12 @@ $(OBJDIR)/ccp.sys: $(OBJDIR)/src/ccp.o $(OBJDIR)/libcpm.a
 $(OBJDIR)/apple2e.bios: $(OBJDIR)/src/bios/apple2e.o $(OBJDIR)/libbios.a scripts/apple2e.ld scripts/apple2e-prelink.ld Makefile
 	@mkdir -p $(dir $@)
 	$(LLVM)ld.lld -T scripts/apple2e-prelink.ld -o $(OBJDIR)/apple2e.o $< $(OBJDIR)/libbios.a --defsym=BIOS_SIZE=0x8000
-	$(LLVM)ld.lld -Map $(patsubst %.bios,%.map,$@) -T scripts/apple2e.ld -o $@ $< $(OBJDIR)/libbios.a --defsym=BIOS_SIZE=$$(llvm-objdump --section-headers $(OBJDIR)/apple2e.o | gawk --non-decimal-data '/ [0-9]+/ { size[$$2] = ("0x"$$3)+0 } END { print(size[".text"] + size[".data"] + size[".bss"]) }')
+	$(LLVM)ld.lld -Map $(patsubst %.bios,%.map,$@) -T scripts/apple2e.ld -o $@ $< $(OBJDIR)/libbios.a --defsym=BIOS_SIZE=$$($(LLVM)llvm-objdump --section-headers $(OBJDIR)/apple2e.o | gawk --non-decimal-data '/ [0-9]+/ { size[$$2] = ("0x"$$3)+0 } END { print(size[".text"] + size[".data"] + size[".bss"]) }')
 
 $(OBJDIR)/oric.exe: $(OBJDIR)/src/bios/oric.o $(OBJDIR)/libbios.a scripts/oric.ld scripts/oric-prelink.ld scripts/oric-common.ld Makefile
 	@mkdir -p $(dir $@)
 	$(LLVM)ld.lld -Map $(patsubst %.exe,%.map,$@) -T scripts/oric-prelink.ld -o $(OBJDIR)/oric-prelink.o $< $(OBJDIR)/libbios.a --defsym=BIOS_SIZE=0x4000
-	$(LLVM)ld.lld -Map $(patsubst %.exe,%.map,$@) -T scripts/oric.ld -o $@ $< $(OBJDIR)/libbios.a --defsym=BIOS_SIZE=$$(llvm-objdump --section-headers $(OBJDIR)/oric-prelink.o | gawk --non-decimal-data '/ [0-9]+/ { size[$$2] = ("0x"$$3)+0 } END { print(size[".text"] + size[".data"] + size[".bss"]) }')
+	$(LLVM)ld.lld -Map $(patsubst %.exe,%.map,$@) -T scripts/oric.ld -o $@ $< $(OBJDIR)/libbios.a --defsym=BIOS_SIZE=$$($(LLVM)llvm-objdump --section-headers $(OBJDIR)/oric-prelink.o | gawk --non-decimal-data '/ [0-9]+/ { size[$$2] = ("0x"$$3)+0 } END { print(size[".text"] + size[".data"] + size[".bss"]) }')
 
 $(OBJDIR)/%.exe: $(OBJDIR)/src/bios/%.o $(OBJDIR)/libbios.a scripts/%.ld
 	@mkdir -p $(dir $@)

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -890,6 +890,14 @@ do_SIO:
     jsr SIOV
 #endif
 
+    lda DSTATS
+    cmp #1
+    beq status_ok
+
+    sec
+    rts
+
+status_ok:
     clc
     rts
 zendproc

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -8,9 +8,7 @@
 ; or
 ; 455 tracks x 18 sectors = 8190 sectors (CP/M FS uses 8176)
 
-; First three tracks are reserved for BIOS and BDOS so there is room to grow.
-; Use Atari OS bootloader to load BDOS instead of requiring DOS.SYS, which
-; is pretty big and useless afterwards as it has no ftell()/fseek()
+; The first track is reserved for the boot code.
 
 #include "zif.inc"
 #include "cpm65.inc"
@@ -188,12 +186,7 @@ init:
 
     ; IOCB0 E: is already open
 
-    ; ptr points to the last kilobyte of RAM before ROM (48+kB machines) or
-    ; a gap (<48kB machines). This is _always_ true for all models.
-    ; This block contains 32 empty bytes, 32 bytes of display list (DL),
-    ; after which the screen memory starts.
-
-    ; Adjust display list to have a scanline of space between text lines to
+    ; Create display list with a scanline of blank space between text lines to
     ; avoid ascenders and descenders touching eachother when we load a
     ; proper 7x8 font from user space.
 


### PR DESCRIPTION
Hi,

Here's a small fix for make LLVM=\<path\> and I updated the comments in atari800.S to reflect the current code. Some comments were referring to the old code before the XL port was done.

Funny how I (we?) never stumbled upon the bootloop bug that was there. ~~Still, I need to check the SIO status after read/write and report an error if one occurred. Right now with CF/SD cards or emulation it hardly ever happens that a sector cannot be read or written to, but on a real floppy drive that's still a real possibility.~~ Read or write sector now return with carry set in case of an error.

I saw your post on AtariAge about your Altirra Basic port. Nice work!

Regards,
Ivo
