### PR TITLE
Two small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ MINIMAL_APPS = \
 	$(OBJDIR)/submit.com \
 	apps/dump.asm \
 	apps/ls.asm \
+	apps/cpm65.inc \
 
 APPS = \
 	$(MINIMAL_APPS) \
@@ -45,7 +46,6 @@ APPS = \
 	$(OBJDIR)/objdump.com \
 	apps/bedit.asm \
 	apps/dinfo.asm \
-	apps/cpm65.inc \
 	apps/drivers.inc \
 	cpmfs/asm.txt \
 	cpmfs/basic.txt \

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ MINIMAL_APPS = \
 	apps/dump.asm \
 	apps/ls.asm \
 	apps/cpm65.inc \
+	apps/drivers.inc \
 
 APPS = \
 	$(MINIMAL_APPS) \
@@ -46,7 +47,6 @@ APPS = \
 	$(OBJDIR)/objdump.com \
 	apps/bedit.asm \
 	apps/dinfo.asm \
-	apps/drivers.inc \
 	cpmfs/asm.txt \
 	cpmfs/basic.txt \
 	cpmfs/bedit.txt \

--- a/apps/a8setfnt.c
+++ b/apps/a8setfnt.c
@@ -16,7 +16,7 @@ static uint8_t mem_end;
 static uint16_t tpa;
 static _Bool warmboot = false;
 
-int main() {
+void main() {
     if (!*FILDAT) {                                     // first run
         tpa = cpm_bios_gettpa();
         mem_base = tpa & 0xff;
@@ -37,7 +37,8 @@ int main() {
 
             cpm_printstring("first run, reserving low memory\r\n"
                             "run again to change font\r\n");
-            return 0;
+
+            return;
         }
     } 
 
@@ -67,12 +68,9 @@ int main() {
 
     *CHBAS = *FILDAT;                       // set font
 
+errout:
     if (warmboot) {
         cpm_get_set_user(0);                // assure we can read CCP.SYS
         cpm_warmboot();
     }
-    return 0;
-
-errout:
-    return 1;
 }


### PR DESCRIPTION
setfnt crashed on non-XL/XE machines on the second run if no font file was specified the first time.
cpm65.inc was missing in the small SD version.
