### PR TITLE
Update bios tty/screen driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,6 @@ TARGETS = \
 MINIMAL_APPS = \
 	$(OBJDIR)/apps/bedit.com \
 	$(OBJDIR)/apps/capsdrv.com \
-	$(OBJDIR)/apps/cls.com \
 	$(OBJDIR)/apps/devices.com \
 	$(OBJDIR)/apps/dinfo.com \
 	$(OBJDIR)/apps/dump.com \
@@ -54,6 +53,7 @@ APPS = \
 	cpmfs/hello.asm \
 
 SCREEN_APPS = \
+	$(OBJDIR)/apps/cls.com \
 	apps/cls.asm \
 	$(OBJDIR)/qe.com \
 

--- a/scripts/atari800.ld
+++ b/scripts/atari800.ld
@@ -19,7 +19,7 @@
 MEMORY {
     zp : ORIGIN = 0x80, LENGTH = 0x80
     ram (rw) : ORIGIN = 0x500, LENGTH = 0x800
-    midram(rw) : ORIGIN = 0x3000, LENGTH = 0x800
+    midram(rw) : ORIGIN = 0x3000, LENGTH = 0xc00
 }
 
 SECTIONS {

--- a/scripts/atari800xlhd.ld
+++ b/scripts/atari800xlhd.ld
@@ -19,7 +19,7 @@
 MEMORY {
     zp : ORIGIN = 0x80, LENGTH = 0x80
     lowram (rw) : ORIGIN = 0x500, LENGTH = 0x800
-    midram(rw) : ORIGIN = 0x3000, LENGTH = 0x800
+    midram(rw) : ORIGIN = 0x3000, LENGTH = 0xc00
     biosram(rw) : ORIGIN = 0xd800, LENGTH = 0x800
     bank_extra(rw) : ORIGIN = 0xe400, LENGTH = 0x1c00
 }

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -403,7 +403,7 @@ screen_jmptable_lo:
     jmptablo screen_putchar
     jmptablo screen_putstring
     jmptablo screen_getchar
-    jmptablo fail
+    jmptablo screen_showcursor
     jmptablo screen_scrollup
     jmptablo screen_scrolldown
     jmptablo screen_cleartoeol
@@ -417,7 +417,7 @@ screen_jmptable_hi:
     jmptabhi screen_putchar
     jmptabhi screen_putstring
     jmptabhi screen_getchar
-    jmptabhi fail
+    jmptabhi screen_showcursor
     jmptabhi screen_scrollup
     jmptabhi screen_scrolldown
     jmptabhi screen_cleartoeol
@@ -865,6 +865,20 @@ zproc show_cursor
     ora #$80
     sta (ptr),y
     rts
+zendproc
+
+zproc screen_showcursor
+    pha
+    jsr hide_cursor
+    pla
+    cmp #0
+    zif_eq
+        lda #$60            ; rts instruction
+    zelse
+        lda #$20            ; jsr instruction
+    zendif
+    sta show_cursor
+    jmp show_cursor
 zendproc
 
 ; ---------------------------------------------------------------------------

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -471,9 +471,22 @@ zproc screen_clear
     rts
 zendproc
 
+; On top of the official specification, we clip (A,X) at the screen edges
+
 zproc screen_setcursor
+    cmp #SCREEN_WIDTH
+    zif_cs
+        lda #SCREEN_WIDTH-1
+    zendif
     sta cursorx
-    stx cursory
+
+    txa
+    cmp #SCREEN_HEIGHT
+    zif_cs
+        lda #SCREEN_HEIGHT-1
+    zendif
+    sta cursory
+
     rts
 zendproc
 

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -407,7 +407,7 @@ screen_jmptable_lo:
     jmptablo screen_scrollup
     jmptablo screen_scrolldown
     jmptablo screen_cleartoeol
-    jmptablo fail
+    jmptablo screen_setstyle
 screen_jmptable_hi:
     jmptabhi screen_version
     jmptabhi screen_getsize
@@ -421,7 +421,7 @@ screen_jmptable_hi:
     jmptabhi screen_scrollup
     jmptabhi screen_scrolldown
     jmptabhi screen_cleartoeol
-    jmptabhi fail
+    jmptabhi screen_setstyle
 zendproc
 
 zproc fail
@@ -530,6 +530,8 @@ zendproc
 zproc screen_putchar
     jsr convert_ascii_to_screencode
     ldy cursorx
+style=.+1
+    eor #$00
     sta (curlineptr), y
 
     lda cursorx
@@ -879,6 +881,17 @@ zproc screen_showcursor
     zendif
     sta show_cursor
     jmp show_cursor
+zendproc
+
+zproc screen_setstyle
+    cmp #STYLE_REVERSE
+    zif_eq
+        lda #$80
+    zelse
+        lda #0
+    zendif
+    sta style
+    rts
 zendproc
 
 ; ---------------------------------------------------------------------------

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -26,9 +26,7 @@ ptr1 = FMSZPG+2
 
 save_y = FMSZPG+4
 
-curlineptr = FMSZPG+5       ; 2 bytes
-
-; 0 bytes of FMSZPG left
+; 2 bytes of FMSZPG left
 
 charin = PTEMP      ; temporary on ZP that we don't use
 charout = PTEMP
@@ -204,11 +202,9 @@ init:
 
     stx dl_prologue+4
     stx SAVMSC+1
-    stx curlineptr+1
     lda #$40
     sta dl_prologue+3
     sta SAVMSC
-    sta curlineptr
 
     zrepeat
         lda dl_prologue,y
@@ -472,16 +468,13 @@ zproc screen_clear
     lda #0
     sta cursorx
     sta cursory
-    jmp show_cursor 
+    rts
 zendproc
 
 zproc screen_setcursor
-    pha
-    jsr hide_cursor
-    pla
     sta cursorx
     stx cursory
-    jmp show_cursor
+    rts
 zendproc
 
 zproc screen_getcursor
@@ -495,6 +488,7 @@ zendproc
 zproc screen_getchar
     sta ptr
     stx ptr+1
+
     clc
     ror ptr+1                       ; divide be two, we can only count
     ror ptr                         ; two centiseconds at a time
@@ -528,11 +522,14 @@ zproc screen_getchar
 zendproc
 
 zproc screen_putchar
+    pha
+    jsr calculate_cursor_address
+    pla
     jsr convert_ascii_to_screencode
     ldy cursorx
 style=.+1
     eor #$00
-    sta (curlineptr), y
+    sta (ptr), y
 
     lda cursorx
     cmp #SCREEN_WIDTH-1
@@ -568,8 +565,6 @@ zproc screen_putstring
 zendproc
 
 zproc screen_scrollup
-    jsr hide_cursor
-
     lda SAVMSC
     sta ptr1
     lda SAVMSC+1
@@ -607,13 +602,10 @@ zproc screen_scrollup
         sta (ptr), y
         dey
     zuntil_mi
-    jmp show_cursor
-
+    rts
 zendproc
 
 zproc screen_scrolldown
-    jsr hide_cursor
-
     lda SAVMSC
     clc
     adc #<((SCREEN_HEIGHT-1)*SCREEN_WIDTH)
@@ -654,21 +646,20 @@ zproc screen_scrolldown
         sta (ptr), y
         dey
     zuntil_mi
-    jmp show_cursor
+    rts
 zendproc
 
 zproc screen_cleartoeol
-; no need to hide cursor, cursor is overwritten
+    jsr calculate_cursor_address
 
-    ldy cursorx
     lda #0                          ; screen memory space
     zrepeat
-        sta (curlineptr), y
+        sta (ptr), y
         iny
         cpy #SCREEN_WIDTH
     zuntil_eq
 
-    jmp show_cursor
+    rts
 zendproc
 
 ; --- TTY DRIVER ------------------------------------------------------------
@@ -676,6 +667,8 @@ zendproc
 ; Blocks and waits for the next keypress; returns it in A.
 
 zproc tty_conin
+    jsr toggle_cursor
+
     ldx #1*16
     lda #CGBIN
     sta ICCOM,x
@@ -699,21 +692,24 @@ zproc tty_conin
     cmp #ATARI_EOL
     zif_eq
         lda #13
-        rts
+        bne 1f
     zendif
 
     cmp #ATARI_BS
     zif_eq
         lda #127            ; DEL not BS
-        rts
+        bne 1f
     zendif
 
     cmp #ATARI_TAB
     zif_eq
         lda #9
-;        rts    [[fallthrough]]
-    zendif
+    zendif                  ; fallthrough
 
+1:
+    pha
+    jsr toggle_cursor
+    pla
     rts
 zendproc
 
@@ -733,14 +729,11 @@ zendproc
 ; Output character in A
 
 zproc tty_conout
-    pha
-    jsr hide_cursor
-    pla
     cmp #13
     zif_eq
         lda #0
         sta cursorx
-        jmp show_cursor
+        rts
     zendif
     cmp #127
     zif_eq
@@ -757,8 +750,8 @@ zproc tty_conout
             zendif
         zendif
         jsr calculate_cursor_address
-        lda #$80                        ; cursor overwrites old character
-        sta (curlineptr),y
+        lda #0                        ; cursor overwrites old character
+        sta (ptr),y
         rts
     zendif
     cmp #10
@@ -774,7 +767,7 @@ zproc tty_conout
     cmp #SCREEN_WIDTH-1
     beq write_nl
 
-    jmp show_cursor
+    rts
 zendproc
 
 zproc write_nl
@@ -788,7 +781,7 @@ zproc write_nl
         dec cursory
         jmp screen_scrollup
     zendif
-    jmp show_cursor
+    rts
 zendproc
 
 ; Preserves X and Y.
@@ -809,7 +802,6 @@ zproc convert_ascii_to_screencode
 zendproc
 
 ; Sets (ptr), y to the location of the cursor.
-; ptr is cached in curlineptr
 
 zproc calculate_cursor_address
     ldy cursorx
@@ -845,42 +837,29 @@ zproc calculate_cursor_address
     clc
     adc SAVMSC
     sta ptr+0
-    sta curlineptr
     lda ptr+1
     and #3
     adc SAVMSC+1
     sta ptr+1
-    sta curlineptr+1
     rts
 
-zproc hide_cursor
-    ldy cursorx
-    lda (curlineptr),y
-    and #$7f
-    sta (curlineptr),y
-    rts
-zendproc
-
-zproc show_cursor
+zproc toggle_cursor
     jsr calculate_cursor_address
     lda (ptr),y
-    ora #$80
+    eor #$80
     sta (ptr),y
     rts
 zendproc
 
 zproc screen_showcursor
-    pha
-    jsr hide_cursor
-    pla
     cmp #0
     zif_eq
         lda #$60            ; rts instruction
     zelse
         lda #$20            ; jsr instruction
     zendif
-    sta show_cursor
-    jmp show_cursor
+    sta toggle_cursor
+    rts
 zendproc
 
 zproc screen_setstyle

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -511,8 +511,8 @@ zproc screen_putchar
 zendproc
 
 zproc screen_putstring
-    sta 1f+0
-    stx 1f+1
+    sta 1f+1
+    stx 1f+2
 
     jsr calculate_cursor_address
     ldx #0
@@ -524,8 +524,12 @@ zproc screen_putstring
         jsr convert_ascii_to_screencode
         sta (ptr), y
         iny
+        cpy #SCREEN_WIDTH
+        zbreakif_eq
         inx
     zendloop
+    dey
+    sty cursorx
 
     rts
 zendproc

--- a/src/bios/atari800.S
+++ b/src/bios/atari800.S
@@ -55,7 +55,7 @@ _start:
     .byte 0
 
 #ifdef ATARI_XL
-    .byte 16            ; (filesize(atari800xlhd.exe)+127)/128
+    .byte 17            ; (filesize(atari800xlhd.exe)+127)/128
 #else
 #   ifdef ATARI_HD
         .byte 13        ; (filesize(atari800hd.exe)+127)/128
@@ -490,7 +490,38 @@ zproc screen_getcursor
     rts
 zendproc
 
+; XZ = timeout in cs
+
 zproc screen_getchar
+    sta ptr
+    stx ptr+1
+    clc
+    ror ptr+1                       ; divide be two, we can only count
+    ror ptr                         ; two centiseconds at a time
+
+    ldy RTCLOK                      ; incremented every 1/50th of a second
+    iny
+
+    zloop
+        ldx CH
+        inx
+        zbreakif_eq                 ; break if key is pending
+        cpy RTCLOK
+        zif_eq
+            iny
+            dec ptr
+            zif_cs
+                dec ptr+1
+                ldx ptr+1
+                cpx #$ff
+                zif_eq
+                    sec             ; timer expired
+                    rts
+                zendif
+            zendif
+        zendif
+    zendloop
+
     jsr tty_conin
     clc
     rts


### PR DESCRIPTION
Hi,

I have made the bios tty and screen drivers work exactly the same as the new tty80/screen80 driver. Implemented missing showcursor and setstyle, and added timeout code to getchar.

![atari002](https://github.com/davidgiven/cpm65/assets/72343/38a3f992-fa5d-4e74-9762-dd1ecdb36add)
![atari003](https://github.com/davidgiven/cpm65/assets/72343/79f044ba-43f4-4677-85bf-ecf5dcc1f77a)

Regards,
Ivo

Edit: and I moved cls.com to SCREEN_APPS :)