### PR TITLE
disable bios cursor before registering our new screen driver

### DIFF
--- a/apps/a8tty80drv.S
+++ b/apps/a8tty80drv.S
@@ -169,6 +169,12 @@ zproc init
     sta next_tty+1
     stx next_tty+2
 
+; disable BIOS cursor
+
+    ldy #SCREEN_SHOWCURSOR
+    lda #0
+    jsr next_screen
+
 ; register new drivers
 
     lda #<drv_screen80


### PR DESCRIPTION
Didn't notice this yesterday because the new 40 columns code and the new 80 columns code were in different branches :)

Now the bios code does not toggle its cursor anymore if the 80 columns driver is loaded and keyboard input is requested.
