### PR TITLE
added tool "cpuinfo" that detects 6502, 65C02 or 65816

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ TARGETS = \
 MINIMAL_APPS = \
 	$(OBJDIR)/apps/bedit.com \
 	$(OBJDIR)/apps/capsdrv.com \
+	$(OBJDIR)/apps/cpuinfo.com \
 	$(OBJDIR)/apps/devices.com \
 	$(OBJDIR)/apps/dinfo.com \
 	$(OBJDIR)/apps/dump.com \
@@ -47,6 +48,7 @@ APPS = \
 	$(OBJDIR)/third_party/altirrabasic/atbasic.com \
 	$(OBJDIR)/objdump.com \
 	apps/bedit.asm \
+	apps/cpuinfo.asm \
 	apps/dinfo.asm \
 	cpmfs/asm.txt \
 	cpmfs/basic.txt \

--- a/apps/cpuinfo.asm
+++ b/apps/cpuinfo.asm
@@ -1,0 +1,45 @@
+\ cpudetect - info about cpu
+
+\ Copyright © 2023 by David Given and Sven Oliver Moll
+
+\ This file is licensed under the terms of the 2-clause BSD license. Please
+\ see the COPYING file in the root project directory for the full text.
+
+.include "cpm65.inc"
+
+start:
+   lda   #$01
+   .byte $eb,$ea \ 6502: sbc #$ea, 65C02: nop:nop, 65816: xba:nop
+   sec
+   lda   #$ea
+   .byte $eb,$ea \ 6502: sbc #$ea, 65C02: nop:nop, 65816: xba:nop
+\ A: 6502: A=$00, 65C02: A=$ea, 65816: A=$01
+   cmp   #$02
+   .zif cs
+      lda   #$02
+   .zendif
+   pha
+   lda   #<txtbase
+   ldx   #>txtbase
+   ldy   #BDOS_PRINTSTRING
+   jsr   BDOS
+
+   ldx   #>txtcpus
+   pla
+   asl   A
+   asl   A
+   asl   A
+   adc   #<txtcpus
+   .zif cs
+      inx
+   .zendif
+   ldy   #BDOS_PRINTSTRING
+   jmp   BDOS
+
+txtbase:
+   .byte "CPU is $"
+txtcpus: \ all texts need to be 8 characters
+   .byte "6502 \r\n$"
+   .byte "65816\r\n$"
+   .byte "65C02\r\n$"
+


### PR DESCRIPTION
Added a small tool that outputs if the system is running on is using an NMOS 6502, a CMOS 65C02 or a 65816 CPU. Since CP/M-65 is capable of running on those processors on the Apple IIe (NMOS), Apple IIc (65C02) and Apple IIgs (65816), I though this might be a nice custom addition.