### PR TITLE
atari port: add missing fonts, move all font stuff to user area 1 again

### DIFF
--- a/src/arch/atari800/build.py
+++ b/src/arch/atari800/build.py
@@ -26,9 +26,9 @@ mkcpmfs(
     items={
         "0:ccp.sys": "src+ccp",
         "0:bdos.sys": "src+bdos",
-        "0:setfnt.com": "src/arch/atari800/utils+setfnt",
-        "0:tty80drv.com": "src/arch/atari800/utils+tty80drv",
-        "0:olivetti.fnt": "third_party/fonts/atari/olivetti.fnt",
+        "1:setfnt.com": "src/arch/atari800/utils+setfnt",
+        "1:tty80drv.com": "src/arch/atari800/utils+tty80drv",
+        "1:olivetti.fnt": "third_party/fonts/atari/olivetti.fnt",
     }
     | MINIMAL_APPS
     | BIG_APPS,
@@ -60,9 +60,17 @@ mkcpmfs(
     items={
         "0:ccp.sys": "src+ccp",
         "0:bdos.sys": "src+bdos",
-        "0:setfnt.com": "src/arch/atari800/utils+setfnt",
-        "0:tty80drv.com": "src/arch/atari800/utils+tty80drv",
+        "1:setfnt.com": "src/arch/atari800/utils+setfnt",
+        "1:tty80drv.com": "src/arch/atari800/utils+tty80drv",
+        "1:amstrad.fnt": "third_party/fonts/atari/amstrad.fnt",
+        "1:apricot.fnt": "third_party/fonts/atari/apricot.fnt",
+        "1:eagle.fnt": "third_party/fonts/atari/eagle.fnt",
+        "1:ibmega.fnt": "third_party/fonts/atari/ibmega.fnt",
+        "1:mbytepc.fnt": "third_party/fonts/atari/mbytepc.fnt",
         "1:olivetti.fnt": "third_party/fonts/atari/olivetti.fnt",
+        "1:phoenix.fnt": "third_party/fonts/atari/phoenix.fnt",
+        "1:toshiba.fnt": "third_party/fonts/atari/toshiba.fnt",
+        "1:verite.fnt": "third_party/fonts/atari/verite.fnt",
     }
     | MINIMAL_APPS
     | MINIMAL_APPS_SRCS
@@ -98,9 +106,17 @@ mkcpmfs(
     items={
         "0:ccp.sys": "src+ccp",
         "0:bdos.sys": "src+bdos",
-        "0:setfnt.com": "src/arch/atari800/utils+setfnt",
-        "0:tty80drv.com": "src/arch/atari800/utils+tty80drv",
+        "1:setfnt.com": "src/arch/atari800/utils+setfnt",
+        "1:tty80drv.com": "src/arch/atari800/utils+tty80drv",
+        "1:setfnt.com": "src/arch/atari800/utils+setfnt",
+        "1:amstrad.fnt": "third_party/fonts/atari/amstrad.fnt",
+        "1:apricot.fnt": "third_party/fonts/atari/apricot.fnt",
+        "1:eagle.fnt": "third_party/fonts/atari/eagle.fnt",
+        "1:ibmega.fnt": "third_party/fonts/atari/ibmega.fnt",
+        "1:mbytepc.fnt": "third_party/fonts/atari/mbytepc.fnt",
         "1:olivetti.fnt": "third_party/fonts/atari/olivetti.fnt",
+        "1:phoenix.fnt": "third_party/fonts/atari/phoenix.fnt",
+        "1:toshiba.fnt": "third_party/fonts/atari/toshiba.fnt",
     }
     | MINIMAL_APPS
     | MINIMAL_APPS_SRCS


### PR DESCRIPTION
Hi David,

This restores the disk images back to how they were before the change of build system.

I noticed the screen tester. It assumes putstring does \r\n which it didn't do before. Commodore PET and Atari screen drivers don't do this. IMHO that is correct behaviour as SCREEN is not a terminal and should not have any knowledge about stuff like backspace, carriage return, and linefeed characters.

I wondered why the intermediate ATR disk images are named atari80, atari80hd and atari80xlhd. Is that a typo or deliberate?

Regards,
Ivo

Edit: and it would be nice if bdos.sys, cpp.sys etc... were cpmchattr'd again to system and read-only. Looks nice if you run ls :smiley: 