### PR TITLE
Screen related fixes

### DIFF
--- a/apps/life.c
+++ b/apps/life.c
@@ -54,9 +54,9 @@ void life(void)
     // Render updated screen
     addr = 0;
 
-    screen_setcursor(0,0);
     for(y=0; y<h; y++) 
     {
+        screen_setcursor(0,y);
         for(x=0; x<(w+1); x++) 
         {
             buf_a[addr]=buf_b[addr];

--- a/apps/scrntest.asm
+++ b/apps/scrntest.asm
@@ -40,15 +40,6 @@
     sta SCREEN+1
     stx SCREEN+2
 
-    \ Clear screen and print help
-    ldy #SCREEN_CLEAR
-    jsr SCREEN
-
-    lda #<string_init
-    ldx #>string_init
-    ldy #SCREEN_PUTSTRING
-    jsr SCREEN
-
     \ Get screen size and initalize variables
 
     ldy #SCREEN_GETSIZE
@@ -61,6 +52,16 @@
 
     lda #0
     sta style
+
+help:
+    \ Clear screen and print help
+    ldy #SCREEN_CLEAR
+    jsr SCREEN
+
+    lda #<string_init
+    ldx #>string_init
+    ldy #BDOS_PRINTSTRING
+    jsr BDOS
 
 mainloop:
     \ Get and store current cursor position
@@ -212,15 +213,7 @@ case_done:
   
     \ Clear screen and print help 
     cmp #'H'
-    .zif eq
-        ldy #SCREEN_CLEAR
-        jsr SCREEN
-        lda #<string_init
-        ldx #>string_init
-        ldy #SCREEN_PUTSTRING
-        jsr SCREEN
-        jmp mainloop
-    .zendif
+    beq help
 
     \ Clear screen and quit 
     cmp #'Q'
@@ -250,7 +243,7 @@ SCREEN:
 .zendproc
 
 string_init:
-    .byte "CP/M-65 Screen driver tester\r\n\n"
+    .byte "CP/M-65 Screen driver tester\r\n\r\n"
     .byte "W,A,S,D - Move cursor\r\n"
     .byte "C - Put character\r\n"
     .byte "P - Put string\r\n"

--- a/src/arch/atari800/atari800.S
+++ b/src/arch/atari800/atari800.S
@@ -633,7 +633,7 @@ zproc screen_scrolldown
     zrepeat
         lda ptr1
         sec
-        sbc #SCREEN_WIDTH-1
+        sbc #SCREEN_WIDTH
         sta ptr
         zif_cc
             dec ptr+1
@@ -646,16 +646,16 @@ zproc screen_scrolldown
             dey
         zuntil_mi
 
-        lda ptr1
-        sta ptr
-        lda ptr1+1
-        sta ptr+1
+        lda ptr
+        sta ptr1
+        lda ptr+1
+        sta ptr1+1
 
         dex
     zuntil_eq
 
     ldy #SCREEN_WIDTH-1
-    lda #' '
+    lda #0                          ; screen memory space
     zrepeat
         sta (ptr), y
         dey


### PR DESCRIPTION
Hi,

This fixes the Atari 40 column SCREEN driver's scrolldown function (tty80drv was already correct).

It also fixes life.com and scrntest.com to work with the PET, Oric and Atari drivers. SCREEN does not know about terminal characters, but TTY does.

All three (PET, Oric and Atari) stop at the right margin when screen_putchar is used. IMHO this is correct. They also advance the cursor by one horizontally, except when they bump against the right margin.

screen_putstring on the other hand behaves differently. PET and Oric write beyond the margin, and even beyond the end of screen memory when on the last line. This could be problematic if there's code or important data after the screen memory. I think this should be corrected. Atari does not write beyond the right margin, similar to putchar.

The PET and Oric port do not advance the cursor position. It stays at the beginning of the string that was written. The Atari port does advance the cursor.

Regards,
Ivo
