### PR TITLE
Add MAME-based emulator tests for smoke testing the platforms.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -11,7 +11,7 @@ jobs:
         repository: 'davidgiven/cpm65'
 
     - name: apt
-      run: sudo apt update && sudo apt install cc1541 cpmtools libfmt-dev fp-compiler moreutils
+      run: sudo apt update && sudo apt install cc1541 cpmtools libfmt-dev fp-compiler moreutils mame
 
     - name: install llvm-mos
       run: |

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -41,4 +41,5 @@ jobs:
           pet8032.d64
           pet8096.d64
           x16.zip
+          snap
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -21,6 +21,11 @@ jobs:
       run: |
         sh scripts/get-roms.sh
 
+    - name: Setup upterm session
+      uses: lhotari/action-upterm@v1
+      with:
+        limit-access-to-actor: true
+
     - name: make
       run: make LLVM=$HOME/llvm-mos/bin -j`nproc` +all +mametest
 
@@ -41,5 +46,4 @@ jobs:
           pet8032.d64
           pet8096.d64
           x16.zip
-          snap
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -18,8 +18,12 @@ jobs:
       run: |
         wget -O - https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz | tar xJf - -C $HOME
 
+    - name: install roms
+      run: |
+        sh scripts/get-roms.sh
+
     - name: make
-      run: make -C cpm65 LLVM=$HOME/llvm-mos/bin
+      run: make -C cpm65 LLVM=$HOME/llvm-mos/bin -j`nproc` +all +mametest
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -9,37 +9,36 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: 'davidgiven/cpm65'
-        path: 'cpm65'
 
     - name: apt
       run: sudo apt update && sudo apt install cc1541 cpmtools libfmt-dev fp-compiler moreutils
 
     - name: install llvm-mos
       run: |
-        wget -O - https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz | tar xJf - -C $HOME
+        wget -q -O - https://github.com/llvm-mos/llvm-mos-sdk/releases/latest/download/llvm-mos-linux.tar.xz | tar xJf - -C $HOME
 
     - name: install roms
       run: |
         sh scripts/get-roms.sh
 
     - name: make
-      run: make -C cpm65 LLVM=$HOME/llvm-mos/bin -j`nproc` +all +mametest
+      run: make LLVM=$HOME/llvm-mos/bin -j`nproc` +all +mametest
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v2
       with:
         name: ${{ github.event.repository.name }}.${{ github.sha }}
         path: |
-          cpm65/apple2e.po
-          cpm65/atari800.atr
-          cpm65/atari800hd.atr
-          cpm65/atari800xlhd.atr
-          cpm65/bbcmicro.ssd
-          cpm65/c64.d64
-          cpm65/diskdefs
-          cpm65/oric.dsk
-          cpm65/pet4032.d64
-          cpm65/pet8032.d64
-          cpm65/pet8096.d64
-          cpm65/x16.zip
+          apple2e.po
+          atari800.atr
+          atari800hd.atr
+          atari800xlhd.atr
+          bbcmicro.ssd
+          c64.d64
+          diskdefs
+          oric.dsk
+          pet4032.d64
+          pet8032.d64
+          pet8096.d64
+          x16.zip
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -21,10 +21,10 @@ jobs:
       run: |
         sh scripts/get-roms.sh
 
-    - name: Setup upterm session
-      uses: lhotari/action-upterm@v1
-      with:
-        limit-access-to-actor: true
+    #- name: Setup upterm session
+    #  uses: lhotari/action-upterm@v1
+    #  with:
+    #    limit-access-to-actor: true
 
     - name: make
       run: make LLVM=$HOME/llvm-mos/bin -j`nproc` +all +mametest

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,5 @@ export OBJ = .obj
 .PHONY: all
 all: +all
 
+TARGETS = +all +mametest
 include build/ab.mk

--- a/README.md
+++ b/README.md
@@ -73,16 +73,26 @@ is available out of the box. Once installed, you should just be able to run the
 Makefile and you'll get bootable disk images for the Commodore 64 (with 1541
 drive) and BBC Micro (producing a 200kB SSSD DFS disk):
 
-    make LLVM=<your llvm-mos bin directory here>/
+    make LLVM=<your llvm-mos bin directory here>/ -j$(nproc)
 
 Building CP/M-65 is a bit of a performance because it's aggregating lots of
 other software, all of which need building in turn. You'll need: a C and C++
 compiler, cc1541 (for creating 1541 disk images), cpmtools (for creating CP/M
-disk images), libfmt (all the C++ tools use this), ninja-build (for the build
+disk images), libfmt (all the C++ tools use this), python3 (for the build
 system), and FreePascal (because the MADS assembler is written in Pascal). Use
 these Debian packages:
 
-    cc1541 cpmtools libfmt-dev ninja-build fp-compiler
+    cc1541 cpmtools libfmt-dev python3 fp-compiler
+
+There are also automated tests which use `mame` to emulate a reasonable number
+of the platforms, to verify that they actually work. To use this, install
+`mame`, and then run `scripts/get-roms.sh` to download the necessary system
+ROMs. Then do:
+
+    make LLVM=<your llvm-mos bin directory here>/ -j$(nproc) +mametest
+
+You can add `+all` to that if you want to do a normal build and run the tests at
+the same time.
 
 ### BBC Micro notes
 

--- a/build.py
+++ b/build.py
@@ -24,3 +24,8 @@ export(
         "x16.zip": "src/arch/x16+diskimage",
     },
 )
+
+export(
+    name="mametest",
+    deps=["src/arch/bbcmicro+mametest", "src/arch/apple2e+mametest"],
+)

--- a/build.py
+++ b/build.py
@@ -30,6 +30,7 @@ export(
     deps=[
         "src/arch/bbcmicro+mametest",
         "src/arch/apple2e+mametest",
-        #"src/arch/atari800+mametest",
+        # "src/arch/atari800+mametest",
+        "src/arch/oric+mametest",
     ],
 )

--- a/build.py
+++ b/build.py
@@ -27,5 +27,9 @@ export(
 
 export(
     name="mametest",
-    deps=["src/arch/bbcmicro+mametest", "src/arch/apple2e+mametest", "src/arch/atari800+mametest"],
+    deps=[
+        "src/arch/bbcmicro+mametest",
+        "src/arch/apple2e+mametest",
+        #"src/arch/atari800+mametest",
+    ],
 )

--- a/build.py
+++ b/build.py
@@ -32,8 +32,10 @@ export(
         "src/arch/commodore+c64_mametest",
         "src/arch/commodore+pet4032_mametest",
         "src/arch/commodore+pet8032_mametest",
-        "src/arch/apple2e+mametest",
-        # "src/arch/atari800+mametest",
+        # Works locally, but not on github CI.
+        #"src/arch/apple2e+mametest",
+        # Fails everywhere.
+        #"src/arch/atari800+mametest",
         "src/arch/oric+mametest",
     ],
 )

--- a/build.py
+++ b/build.py
@@ -30,6 +30,8 @@ export(
     deps=[
         "src/arch/bbcmicro+mametest",
         "src/arch/commodore+c64_mametest",
+        "src/arch/commodore+pet4032_mametest",
+        "src/arch/commodore+pet8032_mametest",
         "src/arch/apple2e+mametest",
         # "src/arch/atari800+mametest",
         "src/arch/oric+mametest",

--- a/build.py
+++ b/build.py
@@ -29,6 +29,7 @@ export(
     name="mametest",
     deps=[
         "src/arch/bbcmicro+mametest",
+        "src/arch/commodore+c64_mametest",
         "src/arch/apple2e+mametest",
         # "src/arch/atari800+mametest",
         "src/arch/oric+mametest",

--- a/build.py
+++ b/build.py
@@ -27,5 +27,5 @@ export(
 
 export(
     name="mametest",
-    deps=["src/arch/bbcmicro+mametest", "src/arch/apple2e+mametest"],
+    deps=["src/arch/bbcmicro+mametest", "src/arch/apple2e+mametest", "src/arch/atari800+mametest"],
 )

--- a/build/ab.mk
+++ b/build/ab.mk
@@ -44,11 +44,13 @@ clean::
 	@echo CLEAN
 	$(hide) rm -rf $(OBJ) bin
 
+TARGETS ?= +all
+
 export PYTHONHASHSEED = 1
 build-files = $(shell find . -name 'build.py') $(wildcard build/*.py) $(wildcard config.py)
 $(OBJ)/build.mk: Makefile $(build-files)
 	@echo "AB"
 	@mkdir -p $(OBJ)
-	$(hide) $(PYTHON) -X pycache_prefix=$(OBJ) build/ab.py -t +all -o $@ \
+	$(hide) $(PYTHON) -X pycache_prefix=$(OBJ) build/ab.py $(patsubst %,-t %,$(TARGETS)) -o $@ \
 		build.py || rm -f $@
 

--- a/scripts/get-roms.sh
+++ b/scripts/get-roms.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+set -e
+
+get_rom() {
+    rom=$2
+    if [ "$rom" = "" ]; then
+        rom=$(basename $1)
+    fi
+    if ! [ -f roms/$rom ]; then
+        mkdir -p roms
+        wget -O roms/$rom $1
+    fi
+}
+
+URL='https://archive.org/download/MAME217RomsOnlyMerged/MAME%200.217%20ROMs%20%28merged%29.zip'
+get_rom $URL/bbcm.zip
+get_rom $URL/saa5050.zip
+get_rom $URL/apple2e.zip
+get_rom $URL/a2diskiing.zip
+get_rom $URL/d2fdc.zip
+get_rom $URL/votrax.zip votrsc01a.zip

--- a/scripts/get-roms.sh
+++ b/scripts/get-roms.sh
@@ -20,3 +20,5 @@ get_rom $URL/apple2e.zip
 get_rom $URL/a2diskiing.zip
 get_rom $URL/d2fdc.zip
 get_rom $URL/votrax.zip votrsc01a.zip
+get_rom $URL/oric1.zip
+get_rom $URL/oric_microdisc.zip

--- a/scripts/get-roms.sh
+++ b/scripts/get-roms.sh
@@ -24,4 +24,13 @@ get_rom $URL/d2fdc.zip
 get_rom $URL/oric1.zip
 get_rom $URL/oric_microdisc.zip
 get_rom $URL/saa5050.zip
+get_rom $URL/vic1001.zip
+get_rom $URL/pet4016.zip
+get_rom $URL/pet4032b.zip
+get_rom $URL/pet8032.zip
+get_rom $URL/c8050.zip
+get_rom $URL/c8050fdc.zip
+get_rom $URL/c4040.zip
+get_rom $URL/c2040_fdc.zip
+get_rom $URL/vic20_fe3.zip vic20.zip
 get_rom $URL/votrax.zip votrsc01a.zip

--- a/scripts/get-roms.sh
+++ b/scripts/get-roms.sh
@@ -33,4 +33,5 @@ get_rom $URL/c8050fdc.zip
 get_rom $URL/c4040.zip
 get_rom $URL/c2040_fdc.zip
 get_rom $URL/vic20_fe3.zip vic20.zip
-get_rom $URL/votrax.zip votrsc01a.zip
+get_rom $URL/votrax.zip
+cp roms/votrax.zip roms/votrsc01a.zip

--- a/scripts/get-roms.sh
+++ b/scripts/get-roms.sh
@@ -8,7 +8,7 @@ get_rom() {
     fi
     if ! [ -f roms/$rom ]; then
         mkdir -p roms
-        wget -O roms/$rom $1
+        wget -q -O roms/$rom $1
     fi
 }
 

--- a/scripts/get-roms.sh
+++ b/scripts/get-roms.sh
@@ -13,12 +13,15 @@ get_rom() {
 }
 
 URL='https://archive.org/download/MAME217RomsOnlyMerged/MAME%200.217%20ROMs%20%28merged%29.zip'
-get_rom $URL/a800xl.zip
-get_rom $URL/bbcm.zip
-get_rom $URL/saa5050.zip
-get_rom $URL/apple2e.zip
+
 get_rom $URL/a2diskiing.zip
+get_rom $URL/a800xl.zip
+get_rom $URL/apple2e.zip
+get_rom $URL/bbcm.zip
+get_rom $URL/c1541.zip
+get_rom $URL/c64.zip
 get_rom $URL/d2fdc.zip
-get_rom $URL/votrax.zip votrsc01a.zip
 get_rom $URL/oric1.zip
 get_rom $URL/oric_microdisc.zip
+get_rom $URL/saa5050.zip
+get_rom $URL/votrax.zip votrsc01a.zip

--- a/scripts/get-roms.sh
+++ b/scripts/get-roms.sh
@@ -13,6 +13,7 @@ get_rom() {
 }
 
 URL='https://archive.org/download/MAME217RomsOnlyMerged/MAME%200.217%20ROMs%20%28merged%29.zip'
+get_rom $URL/a800xl.zip
 get_rom $URL/bbcm.zip
 get_rom $URL/saa5050.zip
 get_rom $URL/apple2e.zip

--- a/scripts/mame-test.sh
+++ b/scripts/mame-test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+diskimage=/tmp/$$.$4
+trap "rm -f $diskimage" EXIT
+cp $2 $diskimage
+SDL_VIDEODRIVER=dummy chronic mame $1 -flop1 $diskimage -video none -autoboot_script $3 -nothrottle -nosleep -snapshot_directory snap -sound none -rompath roms

--- a/scripts/mame-test.sh
+++ b/scripts/mame-test.sh
@@ -4,4 +4,4 @@ set -e
 diskimage=/tmp/$$.$4
 trap "rm -f $diskimage" EXIT
 cp $2 $diskimage
-SDL_VIDEODRIVER=dummy chronic mame $1 -flop1 $diskimage -video none -autoboot_script $3 -nothrottle -nosleep -snapshot_directory snap -sound none -rompath roms
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy chronic mame $1 -flop1 $diskimage -video none -autoboot_script $3 -nothrottle -nosleep -snapshot_directory snap -sound none -rompath roms

--- a/scripts/oric-mame-test.sh
+++ b/scripts/oric-mame-test.sh
@@ -4,4 +4,4 @@ set -e
 diskimage=/tmp/$$.$4
 trap "rm -f $diskimage" EXIT
 cp $2 $diskimage
-SDL_VIDEODRIVER=dummy chronic mame $1 -ext microdisc -flop $diskimage -video none -autoboot_script $3 -nothrottle -nosleep -snapshot_directory snap -sound none -rompath roms
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy chronic mame $1 -ext microdisc -flop $diskimage -video none -autoboot_script $3 -nothrottle -nosleep -snapshot_directory snap -sound none -rompath roms

--- a/scripts/oric-mame-test.sh
+++ b/scripts/oric-mame-test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+diskimage=/tmp/$$.$4
+trap "rm -f $diskimage" EXIT
+cp $2 $diskimage
+SDL_VIDEODRIVER=dummy chronic mame $1 -ext microdisc -flop $diskimage -video none -autoboot_script $3 -nothrottle -nosleep -snapshot_directory snap -sound none -rompath roms

--- a/src/arch/apple2e/build.py
+++ b/src/arch/apple2e/build.py
@@ -1,5 +1,4 @@
-from build.ab import normalrule
-from tools.build import mkdfs, mkcpmfs, shuffle
+from tools.build import mkcpmfs, shuffle, mametest
 from build.llvm import llvmrawprogram, llvmcfile
 from config import (
     MINIMAL_APPS,
@@ -57,4 +56,12 @@ mkcpmfs(
     | MINIMAL_APPS_SRCS
     | BIG_APPS
     | BIG_APPS_SRCS,
+)
+
+mametest(
+    name="mametest",
+    target="apple2e",
+    diskimage=".+diskimage",
+    imagetype=".po",
+    script="./mame-test.lua",
 )

--- a/src/arch/apple2e/mame-test.lua
+++ b/src/arch/apple2e/mame-test.lua
@@ -1,40 +1,43 @@
-local machine = manager.machine
-local kbd = machine.natkeyboard
-local video = machine.video
+local c = coroutine.create(function()
+    local machine = manager.machine
+    local kbd = machine.natkeyboard
+    local video = machine.video
 
-local function wait_kbd()
-    while kbd.is_posting do
-        emu.wait(0.1)
+    local function wait_kbd()
+        while kbd.is_posting do
+            emu.wait(0.1)
+        end
     end
-end
 
-emu.wait(6)
+    emu.wait(6)
 
-kbd:post_coded("BEDIT{ENTER}")
-emu.wait(3)
-kbd:post_coded("10 lda #18{ENTER}") wait_kbd()
-kbd:post_coded("20 ldx #35{ENTER}") wait_kbd()
-kbd:post_coded("30 ldy #52{ENTER}") wait_kbd()
-kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
-kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
-emu.wait(8)
-kbd:post_coded("quit{ENTER}") wait_kbd()
-emu.wait(1)
-kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
-emu.wait(20)
-kbd:post_coded("test{ENTER}") wait_kbd()
-emu.wait(3)
+    kbd:post_coded("BEDIT{ENTER}")
+    emu.wait(3)
+    kbd:post_coded("10 lda #18{ENTER}") wait_kbd()
+    kbd:post_coded("20 ldx #35{ENTER}") wait_kbd()
+    kbd:post_coded("30 ldy #52{ENTER}") wait_kbd()
+    kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+    kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
+    emu.wait(8)
+    kbd:post_coded("quit{ENTER}") wait_kbd()
+    emu.wait(1)
+    kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+    emu.wait(20)
+    kbd:post_coded("test{ENTER}") wait_kbd()
+    emu.wait(3)
 
-local cpu = manager.machine.devices[':maincpu']
-if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
-    print("success!")
-    os.exit(0)
-end
+    local cpu = manager.machine.devices[':maincpu']
+    if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+        print("success!")
+        os.exit(0)
+    end
 
-print("fail")
-video:snapshot()
-for k, v in pairs(cpu.state) do
-    print(k, type(v), tostring(v))
-end
+    print("fail")
+    video:snapshot()
+    for k, v in pairs(cpu.state) do
+        print(k, type(v), tostring(v))
+    end
 
-os.exit(1)
+    os.exit(1)
+end)
+coroutine.resume(c)

--- a/src/arch/apple2e/mame-test.lua
+++ b/src/arch/apple2e/mame-test.lua
@@ -1,0 +1,40 @@
+local machine = manager.machine
+local kbd = machine.natkeyboard
+local video = machine.video
+
+local function wait_kbd()
+    while kbd.is_posting do
+        emu.wait(0.1)
+    end
+end
+
+emu.wait(6)
+
+kbd:post_coded("BEDIT{ENTER}")
+emu.wait(3)
+kbd:post_coded("10 lda #18{ENTER}") wait_kbd()
+kbd:post_coded("20 ldx #35{ENTER}") wait_kbd()
+kbd:post_coded("30 ldy #52{ENTER}") wait_kbd()
+kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
+emu.wait(8)
+kbd:post_coded("quit{ENTER}") wait_kbd()
+emu.wait(1)
+kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+emu.wait(20)
+kbd:post_coded("test{ENTER}") wait_kbd()
+emu.wait(3)
+
+local cpu = manager.machine.devices[':maincpu']
+if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+    print("success!")
+    os.exit(0)
+end
+
+print("fail")
+video:snapshot()
+for k, v in pairs(cpu.state) do
+    print(k, type(v), tostring(v))
+end
+
+os.exit(1)

--- a/src/arch/atari800/build.py
+++ b/src/arch/atari800/build.py
@@ -1,5 +1,5 @@
 from build.ab import normalrule
-from tools.build import mkcpmfs
+from tools.build import mkcpmfs, mametest
 from build.llvm import llvmrawprogram, llvmclibrary
 from config import (
     MINIMAL_APPS,
@@ -119,4 +119,12 @@ normalrule(
         "cat {ins[0]} >> {outs[0]}",
     ],
     label="MAKEATR",
+)
+
+mametest(
+    name="mametest",
+    target="a800xlp",
+    diskimage=".+atari800_diskimage",
+    imagetype=".atr",
+    script="./mame-test.lua",
 )

--- a/src/arch/atari800/build.py
+++ b/src/arch/atari800/build.py
@@ -23,7 +23,7 @@ mkcpmfs(
     name="atari800_rawdiskimage",
     format="atari90",
     bootimage=".+atari800_bios",
-    size=128*720,
+    size=128 * 720,
     items={
         "0:ccp.sys@sr": "src+ccp",
         "0:bdos.sys@sr": "src+bdos",
@@ -58,7 +58,7 @@ mkcpmfs(
     name="atari800hd_rawdiskimage",
     format="atarihd",
     bootimage=".+atari800hd_bios",
-    size=128*8190,
+    size=128 * 8190,
     items={
         "0:ccp.sys@sr": "src+ccp",
         "0:bdos.sys@sr": "src+bdos",
@@ -105,7 +105,7 @@ mkcpmfs(
     name="atari800xlhd_rawdiskimage",
     format="atarihd",
     bootimage=".+atari800xlhd_bios",
-    size=128*8190,
+    size=128 * 8190,
     items={
         "0:ccp.sys@sr": "src+ccp",
         "0:bdos.sys@sr": "src+bdos",

--- a/src/arch/atari800/mame-test.lua
+++ b/src/arch/atari800/mame-test.lua
@@ -8,10 +8,10 @@ local function wait_kbd()
     end
 end
 
-emu.wait(3)
+emu.wait(4)
 
 kbd:post_coded("BEDIT{ENTER}")
-emu.wait(7)
+emu.wait(2)
 kbd:post_coded("10 lda #0x12{ENTER}") wait_kbd()
 kbd:post_coded("20 ldx #0x23{ENTER}") wait_kbd()
 kbd:post_coded("30 ldy #0x34{ENTER}") wait_kbd()

--- a/src/arch/atari800/mame-test.lua
+++ b/src/arch/atari800/mame-test.lua
@@ -1,40 +1,43 @@
-local machine = manager.machine
-local kbd = machine.natkeyboard
-local video = machine.video
+local c = coroutine.create(function()
+    local machine = manager.machine
+    local kbd = machine.natkeyboard
+    local video = machine.video
 
-local function wait_kbd()
-    while kbd.is_posting do
-        emu.wait(0.1)
+    local function wait_kbd()
+        while kbd.is_posting do
+            emu.wait(0.1)
+        end
     end
-end
 
-emu.wait(4)
+    emu.wait(4)
 
-kbd:post_coded("BEDIT{ENTER}")
-emu.wait(2)
-kbd:post_coded("10 lda #0x12{ENTER}") wait_kbd()
-kbd:post_coded("20 ldx #0x23{ENTER}") wait_kbd()
-kbd:post_coded("30 ldy #0x34{ENTER}") wait_kbd()
-kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
-kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
-emu.wait(3)
-kbd:post_coded("quit{ENTER}") wait_kbd()
-emu.wait(3)
-kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
-emu.wait(20)
-kbd:post_coded("test{ENTER}") wait_kbd()
-emu.wait(5)
+    kbd:post_coded("BEDIT{ENTER}")
+    emu.wait(2)
+    kbd:post_coded("10 lda #0x12{ENTER}") wait_kbd()
+    kbd:post_coded("20 ldx #0x23{ENTER}") wait_kbd()
+    kbd:post_coded("30 ldy #0x34{ENTER}") wait_kbd()
+    kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+    kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
+    emu.wait(3)
+    kbd:post_coded("quit{ENTER}") wait_kbd()
+    emu.wait(3)
+    kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+    emu.wait(20)
+    kbd:post_coded("test{ENTER}") wait_kbd()
+    emu.wait(5)
 
-local cpu = manager.machine.devices[':maincpu']
-if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
-    print("success!")
-    os.exit(0)
-end
+    local cpu = manager.machine.devices[':maincpu']
+    if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+        print("success!")
+        os.exit(0)
+    end
 
-print("fail")
-video:snapshot()
-for k, v in pairs(cpu.state) do
-    print(k, type(v), tostring(v))
-end
+    print("fail")
+    video:snapshot()
+    for k, v in pairs(cpu.state) do
+        print(k, type(v), tostring(v))
+    end
 
-os.exit(1)
+    os.exit(1)
+end)
+coroutine.resume(c)

--- a/src/arch/atari800/mame-test.lua
+++ b/src/arch/atari800/mame-test.lua
@@ -1,0 +1,40 @@
+local machine = manager.machine
+local kbd = machine.natkeyboard
+local video = machine.video
+
+local function wait_kbd()
+    while kbd.is_posting do
+        emu.wait(0.1)
+    end
+end
+
+emu.wait(3)
+
+kbd:post_coded("BEDIT{ENTER}")
+emu.wait(7)
+kbd:post_coded("10 lda #0x12{ENTER}") wait_kbd()
+kbd:post_coded("20 ldx #0x23{ENTER}") wait_kbd()
+kbd:post_coded("30 ldy #0x34{ENTER}") wait_kbd()
+kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
+emu.wait(3)
+kbd:post_coded("quit{ENTER}") wait_kbd()
+emu.wait(3)
+kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+emu.wait(20)
+kbd:post_coded("test{ENTER}") wait_kbd()
+emu.wait(5)
+
+local cpu = manager.machine.devices[':maincpu']
+if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+    print("success!")
+    os.exit(0)
+end
+
+print("fail")
+video:snapshot()
+for k, v in pairs(cpu.state) do
+    print(k, type(v), tostring(v))
+end
+
+os.exit(1)

--- a/src/arch/bbcmicro/build.py
+++ b/src/arch/bbcmicro/build.py
@@ -1,5 +1,5 @@
 from build.ab import normalrule
-from tools.build import mkdfs, mkcpmfs
+from tools.build import mkdfs, mkcpmfs, mametest
 from build.llvm import llvmrawprogram
 from config import (
     MINIMAL_APPS,
@@ -39,4 +39,12 @@ mkdfs(
         "bdos": "src+bdos",
         "cpmfs": ".+cpmfs",
     },
+)
+
+mametest(
+    name="mametest",
+    target="bbcm",
+    diskimage=".+diskimage",
+    imagetype=".img",
+    script="./mame-test.lua",
 )

--- a/src/arch/bbcmicro/mame-test.lua
+++ b/src/arch/bbcmicro/mame-test.lua
@@ -26,7 +26,7 @@ coroutine.resume(coroutine.create(function()
     kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
     emu.wait(50)
     kbd:post_coded("test{ENTER}") wait_kbd()
-    emu.wait(10)
+    emu.wait(11)
 
     local cpu = manager.machine.devices[':maincpu']
     if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then

--- a/src/arch/bbcmicro/mame-test.lua
+++ b/src/arch/bbcmicro/mame-test.lua
@@ -1,0 +1,42 @@
+local machine = manager.machine
+local kbd = machine.natkeyboard
+local video = machine.video
+
+local function wait_kbd()
+    while kbd.is_posting do
+        emu.wait(0.1)
+    end
+end
+
+emu.wait(1)
+kbd:post_coded("MODE 135{ENTER}*!boot{ENTER}") wait_kbd()
+emu.wait(11)
+
+kbd:post_coded("BEDIT{ENTER}")
+emu.wait(7)
+kbd:post_coded("10 lda #0x12{ENTER}") wait_kbd()
+kbd:post_coded("20 ldx #0x23{ENTER}") wait_kbd()
+kbd:post_coded("30 ldy #0x34{ENTER}") wait_kbd()
+kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
+emu.wait(10)
+kbd:post_coded("quit{ENTER}") wait_kbd()
+emu.wait(6)
+kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+emu.wait(50)
+kbd:post_coded("test{ENTER}") wait_kbd()
+emu.wait(10)
+
+local cpu = manager.machine.devices[':maincpu']
+if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+    print("success!")
+    os.exit(0)
+end
+
+print("fail")
+video:snapshot()
+for k, v in pairs(cpu.state) do
+    print(k, type(v), tostring(v))
+end
+
+os.exit(1)

--- a/src/arch/bbcmicro/mame-test.lua
+++ b/src/arch/bbcmicro/mame-test.lua
@@ -1,42 +1,44 @@
-local machine = manager.machine
-local kbd = machine.natkeyboard
-local video = machine.video
+coroutine.resume(coroutine.create(function()
+    local machine = manager.machine
+    local kbd = machine.natkeyboard
+    local video = machine.video
 
-local function wait_kbd()
-    while kbd.is_posting do
-        emu.wait(0.1)
+    local function wait_kbd()
+        while kbd.is_posting do
+            emu.wait(0.1)
+        end
     end
-end
 
-emu.wait(1)
-kbd:post_coded("MODE 135{ENTER}*!boot{ENTER}") wait_kbd()
-emu.wait(11)
+    emu.wait(1)
+    kbd:post_coded("MODE 135{ENTER}*!boot{ENTER}") wait_kbd()
+    emu.wait(11)
 
-kbd:post_coded("BEDIT{ENTER}")
-emu.wait(7)
-kbd:post_coded("10 lda #0x12{ENTER}") wait_kbd()
-kbd:post_coded("20 ldx #0x23{ENTER}") wait_kbd()
-kbd:post_coded("30 ldy #0x34{ENTER}") wait_kbd()
-kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
-kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
-emu.wait(10)
-kbd:post_coded("quit{ENTER}") wait_kbd()
-emu.wait(6)
-kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
-emu.wait(50)
-kbd:post_coded("test{ENTER}") wait_kbd()
-emu.wait(10)
+    kbd:post_coded("BEDIT{ENTER}")
+    emu.wait(7)
+    kbd:post_coded("10 lda #0x12{ENTER}") wait_kbd()
+    kbd:post_coded("20 ldx #0x23{ENTER}") wait_kbd()
+    kbd:post_coded("30 ldy #0x34{ENTER}") wait_kbd()
+    kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+    kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
+    emu.wait(10)
+    kbd:post_coded("quit{ENTER}") wait_kbd()
+    emu.wait(6)
+    kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+    emu.wait(50)
+    kbd:post_coded("test{ENTER}") wait_kbd()
+    emu.wait(10)
 
-local cpu = manager.machine.devices[':maincpu']
-if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
-    print("success!")
-    os.exit(0)
-end
+    local cpu = manager.machine.devices[':maincpu']
+    if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+        print("success!")
+        os.exit(0)
+    end
 
-print("fail")
-video:snapshot()
-for k, v in pairs(cpu.state) do
-    print(k, type(v), tostring(v))
-end
+    print("fail")
+    video:snapshot()
+    for k, v in pairs(cpu.state) do
+        print(k, type(v), tostring(v))
+    end
 
-os.exit(1)
+    os.exit(1)
+end))

--- a/src/arch/commodore/build.py
+++ b/src/arch/commodore/build.py
@@ -144,6 +144,6 @@ mametest(
     target="pet8032",
     diskimage=".+pet8032_diskimage",
     imagetype=".d64",
-    runscript="scripts/pet-mame-test.sh",
+    runscript="./pet-mame-test.sh",
     script="./pet-mame-test.lua",
 )

--- a/src/arch/commodore/build.py
+++ b/src/arch/commodore/build.py
@@ -136,6 +136,7 @@ mametest(
     target="pet4032",
     diskimage=".+pet4032_diskimage",
     imagetype=".d64",
+    runscript="./pet-mame-test.sh",
     script="./pet-mame-test.lua",
 )
 

--- a/src/arch/commodore/build.py
+++ b/src/arch/commodore/build.py
@@ -1,5 +1,5 @@
 from build.ab import normalrule, TargetsMap, filenameof, Rule
-from tools.build import mkcpmfs
+from tools.build import mkcpmfs, mametest
 from build.llvm import llvmrawprogram, llvmclibrary
 from config import (
     MINIMAL_APPS,
@@ -122,3 +122,10 @@ for target in ["c64", "vic20"]:
         template=".+%s_cbmfs" % target,
         items=COMMODORE_ITEMS_WITH_SCREEN,
     )
+
+mametest(
+    name="c64_mametest",
+    target="c64",
+    diskimage=".+c64_diskimage",
+    imagetype=".d64",
+    script="./mame-test.lua")

--- a/src/arch/commodore/build.py
+++ b/src/arch/commodore/build.py
@@ -128,4 +128,22 @@ mametest(
     target="c64",
     diskimage=".+c64_diskimage",
     imagetype=".d64",
-    script="./mame-test.lua")
+    script="./mame-test.lua",
+)
+
+mametest(
+    name="pet4032_mametest",
+    target="pet4032",
+    diskimage=".+pet4032_diskimage",
+    imagetype=".d64",
+    script="./pet-mame-test.lua",
+)
+
+mametest(
+    name="pet8032_mametest",
+    target="pet8032",
+    diskimage=".+pet8032_diskimage",
+    imagetype=".d64",
+    runscript="scripts/pet-mame-test.sh",
+    script="./pet-mame-test.lua",
+)

--- a/src/arch/commodore/mame-test.lua
+++ b/src/arch/commodore/mame-test.lua
@@ -1,44 +1,46 @@
-local machine = manager.machine
-local kbd = machine.natkeyboard
-local video = machine.video
+coroutine.resume(coroutine.create(function()
+    local machine = manager.machine
+    local kbd = machine.natkeyboard
+    local video = machine.video
 
-local function wait_kbd()
-    while kbd.is_posting do
-        emu.wait(0.1)
+    local function wait_kbd()
+        while kbd.is_posting do
+            emu.wait(0.1)
+        end
     end
-end
 
-emu.wait(2)
-kbd:post_coded('LOAD"*",8{ENTER}') wait_kbd()
-emu.wait(10)
-kbd:post_coded("RUN{ENTER}") wait_kbd()
-emu.wait(34)
+    emu.wait(2)
+    kbd:post_coded('LOAD"*",8{ENTER}') wait_kbd()
+    emu.wait(10)
+    kbd:post_coded("RUN{ENTER}") wait_kbd()
+    emu.wait(34)
 
-kbd:post_coded("BEDIT{ENTER}") wait_kbd()
-emu.wait(14)
-kbd:post_coded("10 lda #18{ENTER}") wait_kbd()
-kbd:post_coded("20 ldx #35{ENTER}") wait_kbd()
-kbd:post_coded("30 ldy #52{ENTER}") wait_kbd()
-kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
-kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
-emu.wait(20)
-kbd:post_coded("quit{ENTER}") wait_kbd()
-emu.wait(20)
-kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
-emu.wait(135)
-kbd:post_coded("test{ENTER}") wait_kbd()
-emu.wait(10)
+    kbd:post_coded("BEDIT{ENTER}") wait_kbd()
+    emu.wait(14)
+    kbd:post_coded("10 lda #18{ENTER}") wait_kbd()
+    kbd:post_coded("20 ldx #35{ENTER}") wait_kbd()
+    kbd:post_coded("30 ldy #52{ENTER}") wait_kbd()
+    kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+    kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
+    emu.wait(20)
+    kbd:post_coded("quit{ENTER}") wait_kbd()
+    emu.wait(20)
+    kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+    emu.wait(135)
+    kbd:post_coded("test{ENTER}") wait_kbd()
+    emu.wait(10)
 
-local cpu = manager.machine.devices[':u7']
-if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
-    print("success!")
-    os.exit(0)
-end
+    local cpu = manager.machine.devices[':u7']
+    if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+        print("success!")
+        os.exit(0)
+    end
 
-print("fail")
-video:snapshot()
-for k, v in pairs(cpu.state) do
-    print(k, type(v), tostring(v))
-end
+    print("fail")
+    video:snapshot()
+    for k, v in pairs(cpu.state) do
+        print(k, type(v), tostring(v))
+    end
 
-os.exit(1)
+    os.exit(1)
+end))

--- a/src/arch/commodore/mame-test.lua
+++ b/src/arch/commodore/mame-test.lua
@@ -1,0 +1,44 @@
+local machine = manager.machine
+local kbd = machine.natkeyboard
+local video = machine.video
+
+local function wait_kbd()
+    while kbd.is_posting do
+        emu.wait(0.1)
+    end
+end
+
+emu.wait(2)
+kbd:post_coded('LOAD"*",8{ENTER}') wait_kbd()
+emu.wait(10)
+kbd:post_coded("RUN{ENTER}") wait_kbd()
+emu.wait(34)
+
+kbd:post_coded("BEDIT{ENTER}") wait_kbd()
+emu.wait(14)
+kbd:post_coded("10 lda #18{ENTER}") wait_kbd()
+kbd:post_coded("20 ldx #35{ENTER}") wait_kbd()
+kbd:post_coded("30 ldy #52{ENTER}") wait_kbd()
+kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
+emu.wait(20)
+kbd:post_coded("quit{ENTER}") wait_kbd()
+emu.wait(20)
+kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+emu.wait(135)
+kbd:post_coded("test{ENTER}") wait_kbd()
+emu.wait(10)
+
+local cpu = manager.machine.devices[':u7']
+if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+    print("success!")
+    os.exit(0)
+end
+
+print("fail")
+video:snapshot()
+for k, v in pairs(cpu.state) do
+    print(k, type(v), tostring(v))
+end
+
+os.exit(1)

--- a/src/arch/commodore/pet-mame-test.lua
+++ b/src/arch/commodore/pet-mame-test.lua
@@ -15,7 +15,7 @@ coroutine.resume(coroutine.create(function()
     kbd:post_coded("run{ENTER}") wait_kbd()
     emu.wait(15)
 
-    kbd:post_coded("BEDIT{ENTER}") wait_kbd()
+    kbd:post_coded("bedit{ENTER}") wait_kbd()
     emu.wait(14)
     kbd:post_coded("10 lda #18{ENTER}") wait_kbd()
     kbd:post_coded("20 ldx #35{ENTER}") wait_kbd()

--- a/src/arch/commodore/pet-mame-test.lua
+++ b/src/arch/commodore/pet-mame-test.lua
@@ -1,0 +1,46 @@
+coroutine.resume(coroutine.create(function()
+    local machine = manager.machine
+    local kbd = machine.natkeyboard
+    local video = machine.video
+
+    local function wait_kbd()
+        while kbd.is_posting do
+            emu.wait(0.1)
+        end
+    end
+
+    emu.wait(2)
+    kbd:post_coded('dload"cpm"{ENTER}') wait_kbd()
+    emu.wait(5)
+    kbd:post_coded("run{ENTER}") wait_kbd()
+    emu.wait(15)
+
+    kbd:post_coded("BEDIT{ENTER}") wait_kbd()
+    emu.wait(14)
+    kbd:post_coded("10 lda #18{ENTER}") wait_kbd()
+    kbd:post_coded("20 ldx #35{ENTER}") wait_kbd()
+    kbd:post_coded("30 ldy #52{ENTER}") wait_kbd()
+    kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+    kbd:post_coded("save \"test.asm\"{ENTER}") wait_kbd()
+    emu.wait(10)
+    kbd:post_coded("quit{ENTER}") wait_kbd()
+    emu.wait(10)
+    kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+    emu.wait(50)
+    kbd:post_coded("test{ENTER}") wait_kbd()
+    emu.wait(5)
+
+    local cpu = manager.machine.devices[':f3']
+    if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+        print("success!")
+        os.exit(0)
+    end
+
+    print("fail")
+    video:snapshot()
+    for k, v in pairs(cpu.state) do
+        print(k, type(v), tostring(v))
+    end
+
+    os.exit(1)
+end))

--- a/src/arch/commodore/pet-mame-test.sh
+++ b/src/arch/commodore/pet-mame-test.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+diskimage=/tmp/$$.$4
+trap "rm -f $diskimage" EXIT
+cp $2 $diskimage
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy chronic mame $1 -ieee8 c4040 -flop1 $diskimage -video none -autoboot_script $3 -nothrottle -nosleep -snapshot_directory snap -sound none -rompath roms

--- a/src/arch/oric/build.py
+++ b/src/arch/oric/build.py
@@ -1,5 +1,5 @@
 from build.ab import normalrule
-from tools.build import mkcpmfs, mkoricdsk
+from tools.build import mkcpmfs, mkoricdsk, mametest
 from build.llvm import llvmrawprogram, llvmcfile
 from config import (
     MINIMAL_APPS,
@@ -54,3 +54,12 @@ mkcpmfs(
 )
 
 mkoricdsk(name="diskimage", src=".+cpmfs")
+
+mametest(
+    name="mametest",
+    target="oric1",
+    runscript="scripts/oric-mame-test.sh",
+    diskimage=".+diskimage",
+    imagetype=".dsk",
+    script="./mame-test.lua",
+)

--- a/src/arch/oric/build.py
+++ b/src/arch/oric/build.py
@@ -1,4 +1,3 @@
-from build.ab import normalrule
 from tools.build import mkcpmfs, mkoricdsk, mametest
 from build.llvm import llvmrawprogram, llvmcfile
 from config import (

--- a/src/arch/oric/mame-test.lua
+++ b/src/arch/oric/mame-test.lua
@@ -1,0 +1,40 @@
+local machine = manager.machine
+local kbd = machine.natkeyboard
+local video = machine.video
+
+local function wait_kbd()
+    while kbd.is_posting do
+        emu.wait(0.1)
+    end
+end
+
+emu.wait(11)
+
+kbd:post_coded("BEDIT{ENTER}")
+emu.wait(5)
+kbd:post_coded("10 lda #0x12{ENTER}") wait_kbd()
+kbd:post_coded("20 ldx #0x23{ENTER}") wait_kbd()
+kbd:post_coded("30 ldy #0x34{ENTER}") wait_kbd()
+kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+kbd:post_coded("save test.asm{ENTER}") wait_kbd()
+emu.wait(7)
+kbd:post_coded("quit{ENTER}") wait_kbd()
+emu.wait(6)
+kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+emu.wait(40)
+kbd:post_coded("test{ENTER}") wait_kbd()
+emu.wait(3)
+
+local cpu = manager.machine.devices[':maincpu']
+if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+    print("success!")
+    os.exit(0)
+end
+
+print("fail")
+video:snapshot()
+for k, v in pairs(cpu.state) do
+    print(k, type(v), tostring(v))
+end
+
+os.exit(1)

--- a/src/arch/oric/mame-test.lua
+++ b/src/arch/oric/mame-test.lua
@@ -1,40 +1,42 @@
-local machine = manager.machine
-local kbd = machine.natkeyboard
-local video = machine.video
+coroutine.resume(coroutine.create(function()
+    local machine = manager.machine
+    local kbd = machine.natkeyboard
+    local video = machine.video
 
-local function wait_kbd()
-    while kbd.is_posting do
-        emu.wait(0.1)
+    local function wait_kbd()
+        while kbd.is_posting do
+            emu.wait(0.1)
+        end
     end
-end
 
-emu.wait(11)
+    emu.wait(11)
 
-kbd:post_coded("BEDIT{ENTER}")
-emu.wait(5)
-kbd:post_coded("10 lda #0x12{ENTER}") wait_kbd()
-kbd:post_coded("20 ldx #0x23{ENTER}") wait_kbd()
-kbd:post_coded("30 ldy #0x34{ENTER}") wait_kbd()
-kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
-kbd:post_coded("save test.asm{ENTER}") wait_kbd()
-emu.wait(7)
-kbd:post_coded("quit{ENTER}") wait_kbd()
-emu.wait(6)
-kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
-emu.wait(40)
-kbd:post_coded("test{ENTER}") wait_kbd()
-emu.wait(3)
+    kbd:post_coded("BEDIT{ENTER}")
+    emu.wait(5)
+    kbd:post_coded("10 lda #0x12{ENTER}") wait_kbd()
+    kbd:post_coded("20 ldx #0x23{ENTER}") wait_kbd()
+    kbd:post_coded("30 ldy #0x34{ENTER}") wait_kbd()
+    kbd:post_coded("40 label: jmp label{ENTER}") wait_kbd()
+    kbd:post_coded("save test.asm{ENTER}") wait_kbd()
+    emu.wait(7)
+    kbd:post_coded("quit{ENTER}") wait_kbd()
+    emu.wait(6)
+    kbd:post_coded("asm test.asm test.com{ENTER}") wait_kbd()
+    emu.wait(40)
+    kbd:post_coded("test{ENTER}") wait_kbd()
+    emu.wait(3)
 
-local cpu = manager.machine.devices[':maincpu']
-if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
-    print("success!")
-    os.exit(0)
-end
+    local cpu = manager.machine.devices[':maincpu']
+    if (tostring(cpu.state.A) == "12") and (tostring(cpu.state.X) == "23") and (tostring(cpu.state.Y) == "34") then
+        print("success!")
+        os.exit(0)
+    end
 
-print("fail")
-video:snapshot()
-for k, v in pairs(cpu.state) do
-    print(k, type(v), tostring(v))
-end
+    print("fail")
+    video:snapshot()
+    for k, v in pairs(cpu.state) do
+        print(k, type(v), tostring(v))
+    end
 
-os.exit(1)
+    os.exit(1)
+end))

--- a/tools/build.py
+++ b/tools/build.py
@@ -151,3 +151,26 @@ def mkoricdsk(self, name, src: Target = None):
         commands=["{deps[0]} -i {ins[0]} -o {outs[0]}"],
         label="MKORICDSK",
     )
+
+
+@Rule
+def mametest(
+    self,
+    name,
+    target,
+    diskimage: Target = None,
+    imagetype=".img",
+    script: Target = None,
+):
+    normalrule(
+        replaces=self,
+        ins=[diskimage, script],
+        outs=["stamp"],
+        deps=["scripts/mame-test.sh"],
+        commands=[
+            "sh {deps[0]} %s %s %s %s"
+            % (target, filenameof(diskimage), filenameof(script), imagetype),
+            "touch {outs[0]}",
+        ],
+        label="MAMETEST",
+    )

--- a/tools/build.py
+++ b/tools/build.py
@@ -158,6 +158,7 @@ def mametest(
     self,
     name,
     target,
+    runscript: Target = "scripts/mame-test.sh",
     diskimage: Target = None,
     imagetype=".img",
     script: Target = None,
@@ -166,7 +167,7 @@ def mametest(
         replaces=self,
         ins=[diskimage, script],
         outs=["stamp"],
-        deps=["scripts/mame-test.sh"],
+        deps=[runscript],
         commands=[
             "sh {deps[0]} %s %s %s %s"
             % (target, filenameof(diskimage), filenameof(script), imagetype),


### PR DESCRIPTION
There's now an optional stage (`make +mametests`) which will fire up most of the platforms in MAME and try to assemble and run a simple program with them.