### PR TITLE
asm: allow ";" to start a comment

### DIFF
--- a/apps/asm.c
+++ b/apps/asm.c
@@ -376,7 +376,7 @@ static char consumeToken()
     if (currentByte == '\n')
     {
         currentFile->lineNumber++;
-        currentByte = ';';
+        currentByte = ':';
     }
 
     switch (currentByte)

--- a/apps/asm.c
+++ b/apps/asm.c
@@ -360,7 +360,7 @@ static char consumeToken()
 
     for (;;)
     {
-        if (currentByte == '\\')
+        if ((currentByte == '\\') || (currentByte == ';'))
         {
             do
                 consumeByte();


### PR DESCRIPTION
I'm having a big problem with "\" starting a comment. Every 6502 assembler I've worked with so far was using ";" for this. So I added this feature to "asm.com" as well.