### PR TITLE
Fix lockup during repeated keys when using screen_getchar with timeout

### DIFF
--- a/src/arch/atari800/atari800.S
+++ b/src/arch/atari800/atari800.S
@@ -496,7 +496,7 @@ zproc screen_getcursor
     rts
 zendproc
 
-; XZ = timeout in cs
+; XA = timeout in cs
 
 zproc screen_getchar
     sta ptr
@@ -508,6 +508,9 @@ zproc screen_getchar
 
     ldy RTCLOK                      ; incremented every 1/50th of a second
     iny
+
+    lda #$ff
+    sta CH
 
     zloop
         ldx CH


### PR DESCRIPTION
See title :)
