### PR TITLE
Atari SCREEN fix

### DIFF
--- a/src/arch/atari800/atari800.S
+++ b/src/arch/atari800/atari800.S
@@ -512,7 +512,7 @@ zproc screen_getchar
     zloop
         ldx CH
         inx
-        zbreakif_eq                 ; break if key is pending
+        zbreakif_ne                 ; break if key is pending
         cpy RTCLOK
         zif_eq
             iny

--- a/src/arch/atari800/atari800.S
+++ b/src/arch/atari800/atari800.S
@@ -496,7 +496,7 @@ zproc screen_getcursor
     rts
 zendproc
 
-; XZ = timeout in cs
+; XA = timeout in cs
 
 zproc screen_getchar
     sta ptr

--- a/src/arch/atari800/atari800.S
+++ b/src/arch/atari800/atari800.S
@@ -509,6 +509,8 @@ zproc screen_getchar
     ldy RTCLOK                      ; incremented every 1/50th of a second
     iny
 
+    jsr toggle_cursor
+
     zloop
         ldx CH
         inx
@@ -522,6 +524,7 @@ zproc screen_getchar
                 ldx ptr+1
                 cpx #$ff
                 zif_eq
+                    jsr toggle_cursor
                     sec             ; timer expired
                     rts
                 zendif
@@ -530,6 +533,7 @@ zproc screen_getchar
         zendif
     zendloop
 
+    jsr toggle_cursor
     jsr tty_conin
     clc
     rts


### PR DESCRIPTION
I had the logic the wrong way around while waiting with a timeout.

When that was fixed, the cursor was mostly invisible, so fixed that, too.
