### PR TITLE
Bedit: Fixed call to BDOS_CONIO in list_files

### DIFF
--- a/apps/bedit.asm
+++ b/apps/bedit.asm
@@ -962,7 +962,7 @@ dec_table:
 
         jsr print_current_line
 
-        lda #0xff
+        ldx #0xff
         ldy #BDOS_CONIO
         jsr BDOS
         tax


### PR DESCRIPTION
Parameter to BDOS_CONIO was loaded into A instead of X, causing a print of 0xFF instead of a check for keypress after each printed line.

Fixes #77.