### PR TITLE
Terminal emulator with VT52 support and Xmodem send/receive + vt52driver

### DIFF
--- a/apps/build.py
+++ b/apps/build.py
@@ -30,6 +30,8 @@ for prog in [
     "ls",
     "scrntest",
     "xrecv",
+    "vt52drv",
+    "vt52test",
 ]:
     asm(name=prog, src=("./%s.asm" % prog), deps=["./cpm65.inc", "./drivers.inc"])
 

--- a/apps/build.py
+++ b/apps/build.py
@@ -35,5 +35,5 @@ for prog in [
 
 # Simple C programs.
 
-for prog in ["asm", "copy", "stat", "submit", "objdump", "qe", "life"]:
+for prog in ["asm", "copy", "stat", "submit", "objdump", "qe", "life", "vt52term"]:
     llvmprogram(name=prog, srcs=["./%s.c" % prog], deps=["lib+cpm65"])

--- a/apps/vt52drv.asm
+++ b/apps/vt52drv.asm
@@ -1,0 +1,477 @@
+\ This file is licensed under the terms of the 2-clause BSD license. Please
+\ see the COPYING file in the root project directory for the full text.
+
+.include "cpm65.inc"
+.include "drivers.inc"
+
+.expand 1
+
+.label entry
+.label next
+.label noscreen
+.label SCREEN
+.label par_done
+.label mescdone
+
+ESC = 0x1b
+BELL = 0x07
+BACKSPACE = 0x08
+TAB = 0x09
+CR = 0x0d
+LF = 0x0a
+
+\ --- Resident part starts at the top of the file ---------------------------
+
+.bss max_x,1
+.bss max_y,1
+.bss cur_x,1
+.bss cur_y,1
+.bss mEsc, 1
+.bss parse, 1
+.bss cnt, 1
+.bss inp, 1
+.zproc start
+    jmp entry
+.zendproc
+
+driver:
+    .word DRVID_TTY
+    .word strategy
+    .word 0
+    .byte "VT52TTY", 0
+
+.zproc strategy
+    cpy #TTY_CONOUT
+    .zif eq
+        sta inp
+        ldy #SCREEN_GETCURSOR
+        jsr SCREEN
+        sta cur_x
+        stx cur_y
+        lda #1
+        sta parse
+        
+        lda inp
+
+        cmp #32
+        .zif cs
+            cmp #127
+            .zif cc
+                lda mEsc
+
+                cmp #0
+                .zif eq
+                    \ Regular ASCII
+                    lda inp
+                    ldy #SCREEN_PUTCHAR
+                    jsr SCREEN
+                    inc cur_x
+                    lda cur_x
+                    cmp max_x
+                    .zif cs
+                        lda #0
+                        sta cur_x
+                        inc cur_y
+                    .zendif
+                    lda cur_x
+                    ldx cur_y
+                    ldy #SCREEN_SETCURSOR
+                    jsr SCREEN
+                    lda #0
+                    sta parse
+                    jmp mescdone
+                .zendif            
+                
+                cmp #1
+                .zif eq
+                    \ escape sequence. Do nothing
+                    jmp mescdone
+                .zendif
+            
+                cmp #2
+                .zif eq
+                    \ First part of cursor adressing
+                    lda inp
+                    sta mEsc
+                    lda #0
+                    sta parse
+                    jmp mescdone        
+                .zendif
+                
+                \ All other values - second part of cursor adressing
+                sec
+                lda inp
+                sbc #32
+                sta cur_x
+
+                sec
+                lda mEsc
+                sbc #32
+                sta cur_y
+                
+                lda cur_x
+                ldx cur_y
+                ldy #SCREEN_SETCURSOR
+                jsr SCREEN
+                
+                lda #0
+                sta parse
+                sta mEsc
+
+                mescdone:
+            .zendif
+        .zendif
+       
+        lda inp
+        cmp #127
+        .zif eq
+            lda #BACKSPACE
+            sta inp
+        .zendif
+         
+        lda parse
+        cmp #1
+        .zif eq
+            lda inp
+            
+            cmp #CR
+            .zif eq
+                lda #0
+                sta cur_x
+                jmp par_done
+            .zendif
+            
+            cmp #LF
+            .zif eq
+                inc cur_y
+                lda cur_y
+                cmp max_y
+                .zif cs
+                    lda max_y
+                    sta cur_y
+                    ldy #SCREEN_SCROLLUP
+                    jsr SCREEN 
+                .zendif
+                jmp par_done 
+            .zendif
+            
+            cmp #BACKSPACE
+            .zif eq
+                dec cur_x
+                lda cur_x
+                ldx cur_y
+                ldy #SCREEN_SETCURSOR
+                jsr SCREEN 
+                lda #' '
+                ldy #SCREEN_PUTCHAR
+                jsr SCREEN
+                jmp par_done
+            .zendif
+
+            cmp #TAB
+            .zif eq
+                \ Tab to be implemented, need to figure out how to do mod 8
+                lda cur_x
+                clc
+                adc #8
+                and #0xf8
+                cmp max_x
+                .zif cs
+                    lda max_x
+                .zendif
+                sta cur_x
+                jmp par_done
+            .zendif
+
+            cmp #ESC
+            .zif eq
+                \ Start of escape sequence
+                lda #1
+                sta mEsc
+                jmp par_done
+            .zendif
+
+            cmp #'A'
+            .zif eq
+                \ Cursor up
+                lda #0
+                sta mEsc
+                
+                lda cur_y
+                .zif ne
+                    dec cur_y
+                .zendif
+                jmp par_done
+            .zendif
+
+            cmp #'B'
+            .zif eq
+                \ Cursow down
+                lda #0
+                sta mEsc
+                lda cur_y
+                cmp max_y
+                .zif ne
+                    inc cur_y
+                .zendif
+                jmp par_done
+            .zendif
+            
+            cmp #'C'
+            .zif eq
+                \ Cursor right
+                lda #0
+                sta mEsc
+                lda cur_x
+                cmp max_x
+                .zif ne
+                    inc cur_x
+                .zendif
+               jmp par_done 
+            .zendif
+
+            cmp #'D'
+            .zif eq
+                \ Cursor left
+                lda #0
+                sta mEsc
+                lda cur_x
+                .zif ne
+                    dec cur_x
+                .zendif
+                jmp par_done
+            .zendif
+
+            cmp #'F'
+            .zif eq
+                \ Enter graphics mode, ignore
+                lda #0
+                sta mEsc
+                jmp par_done
+            .zendif
+        
+            cmp #'G'
+            .zif eq
+                \ Exit graphics mode, ignore
+                lda #0
+                sta mEsc
+                jmp par_done
+            .zendif
+            
+            cmp #'H'
+            .zif eq
+                \ Cursor home
+                lda #0
+                sta mEsc
+                sta cur_x
+                sta cur_y
+                jmp par_done
+            .zendif
+            
+            cmp #'I'
+            .zif eq
+                \ Reverse line feed
+                lda #0
+                sta mEsc
+                lda cur_y
+                .zif ne
+                    dec cur_y
+                    jmp par_done
+                .zendif
+                lda #0
+                sta cur_y
+                ldy #SCREEN_SCROLLDOWN
+                jsr SCREEN
+                jmp par_done 
+            .zendif            
+            
+            cmp #'J'
+            .zif eq
+                \ Erase to end of screen
+                lda #0
+                sta mEsc
+                ldy #SCREEN_CLEARTOEOL
+                jsr SCREEN
+                ldx cur_y
+                cpx max_y
+                beq par_done
+                inx
+                .zloop
+                    stx cnt
+                    lda #0
+                    ldy #SCREEN_SETCURSOR
+                    jsr SCREEN
+                    
+                    ldy #SCREEN_CLEARTOEOL
+                    jsr SCREEN
+                    ldx cnt
+                    inx
+                    cpx max_y
+                    .zbreak cs
+                .zendloop
+                jmp par_done
+            .zendif
+
+            cmp #'K'
+            .zif eq
+                \ Erase to end of line
+                lda #0
+                sta mEsc
+                ldy #SCREEN_CLEARTOEOL
+                jsr SCREEN
+                jmp par_done
+            .zendif
+
+            cmp #'Y'
+            .zif eq
+                \ Cursor addressing
+                lda #2
+                sta mEsc
+                jmp par_done
+            .zendif
+
+            cmp #'['
+            .zif eq
+                \ Enter hold screen mode, ignore
+                lda #0
+                sta mEsc
+                jmp par_done
+            .zendif
+ 
+            cmp #'\\'
+            .zif eq
+                \ Exit hold screen mode, ignore
+                lda #0
+                sta mEsc
+                jmp par_done
+            .zendif
+ 
+            cmp #'='
+            .zif eq
+                \ Enter alternate keypad mode, ignore
+                lda #0
+                sta mEsc
+                jmp par_done
+            .zendif
+ 
+            cmp #'>'
+            .zif eq
+                \ Exit alternate keypad mode, ignore
+                lda #0
+                sta mEsc
+                jmp par_done
+            .zendif
+ 
+
+            par_done:
+            lda cur_x
+            ldx cur_y
+            ldy #SCREEN_SETCURSOR
+            jsr SCREEN            
+
+        .zendif
+        rts
+    .zendif
+    \lda inp
+    jmp (next)
+.zendproc
+
+SCREEN:
+    jmp 0
+
+next: .word 0
+
+\ --- Resident part stops here -------------------------------------------
+
+.zproc entry
+    
+    ldy #BDOS_GET_BIOS
+    jsr BDOS
+    sta BIOS+1
+    stx BIOS+2
+
+    \ Find SCREEN driver and place the jump to it in the resident part
+    lda #<DRVID_SCREEN
+    ldx #>DRVID_SCREEN
+    ldy #BIOS_FINDDRV
+    jsr BIOS
+
+    \ Print error message and exit if not found
+    .zif cs
+        lda #<noscreen
+        ldx #>noscreen
+        ldy #BDOS_PRINTSTRING
+        jsr BDOS
+        rts
+    .zendif        
+    
+    sta SCREEN+1
+    stx SCREEN+2    
+
+    lda #<banner
+    ldx #>banner
+    ldy #BDOS_PRINTSTRING
+    jsr BDOS
+
+    \ Get screen size and store in resident variables
+    ldy #SCREEN_GETSIZE
+    jsr SCREEN
+    sta max_x
+    stx max_y   
+
+    \ Initialize resident variables
+    lda #0
+    sta mEsc
+
+    \ Find the old TTY driver strategy routine and save it.
+
+    lda #<DRVID_TTY
+    ldx #>DRVID_TTY
+    ldy #BIOS_FINDDRV
+    jsr BIOS
+    .zif cc
+        sta next+0
+        stx next+1
+
+        \ Register the new TTY driver.
+
+        lda #<driver
+        ldx #>driver
+        ldy #BIOS_ADDDRV
+        jsr BIOS
+        .zif cc
+
+            \ Our driver uses no ZP, so we don't need to adjust that. But it does use
+            \ TPA.
+
+            ldy #BIOS_GETTPA
+            jsr BIOS
+            clc
+            adc #4 \ Allocate 4 pages. We should be using entry to calculate this, but
+                   \ the assembler can't do that yet.
+            ldy #BIOS_SETTPA
+            jsr BIOS
+
+            \ Finished --- don't even need to warm boot.
+
+            rts
+        .zendif
+    .zendif
+
+    lda #<failed
+    ldx #>failed
+    ldy #BDOS_PRINTSTRING
+    jmp BDOS
+    
+banner:
+    .byte "The TTY driver is now VT52 capable", 13, 10, 0
+failed:
+    .byte "Failed!", 13, 10, 0
+noscreen:
+    .byte "SCREEN driver not found!", 13, 10, 0
+BIOS:
+    jmp 0
+
+\ vim: sw=4 ts=4 et
+
+

--- a/apps/vt52term.c
+++ b/apps/vt52term.c
@@ -27,6 +27,14 @@
 #include "lib/serial.h"
 #include "lib/screen.h"
 
+#define ESC         0x1b
+#define BELL        0x07
+#define BACKSPACE   0x08
+#define TAB         0x09
+#define CR          0x0d
+#define LF          0x0a
+#define LOCAL_CMD   0x11   // ctrl+q
+
 static void cr(void) 
 {
     cpm_printstring("\n\r");
@@ -95,10 +103,10 @@ int main(void)
             if((parse == 1) && (inp != 0)) {
                 screen_getcursor(&cur_x, &cur_y);
                 switch(inp) {
-                    case 0x0d:
+                    case CR:
                         cur_x = 0;
                         break;
-                    case 0x0a:
+                    case LF:
                         cur_y++;
                         if(cur_y > h) {
                             cur_y = h;
@@ -106,17 +114,17 @@ int main(void)
                         }
                         
                         break;
-                    case 0x08:
+                    case BACKSPACE:
                         cur_x--;
                         break;
-                    case 0x09:
+                    case TAB:
                         cur_x = cur_x + 8 - (cur_x % 8);
                         if(cur_x > w) cur_x = w;
                         break;
-                    case 0x07:
+                    case BELL:
                         // Bell, ignore
                         break;
-                    case 0x1b:
+                    case ESC:
                         // Escape
                         mEsc = 1;
                         break;
@@ -219,7 +227,7 @@ int main(void)
         if(cpm_const()) {
             // Use cpm_bios_conin as cpm_conin crashes...
             inp = cpm_bios_conin();
-            if(inp == 0x11) { // Ctrl+Q, check for local commands
+            if(inp == LOCAL_CMD) { // Ctrl+Q, check for local commands
                 inp = cpm_bios_conin();
                 switch(inp) {
                     case 'q':

--- a/apps/vt52term.c
+++ b/apps/vt52term.c
@@ -1,0 +1,248 @@
+/* vt52term - Copyright (c) Henrik Löfgren
+ * This program is redistributable under the terms of the 2-clause BSD license.
+ * See LICENSE in the distribution root directory for more information
+ *
+ * A VT52 terminal emulator for CP/M-65. Works well enough to login and run
+ * vim on a linux server (if the shell is configured correctly for VT52).
+ * Requires SCREEN and SERIAL drivers.
+ * 
+ * VT52 parsing code heavily inspired by Kenneth Gobers VT52 terminal emulator for 
+ * windows, see https://github.com/kgober/VT52/
+ *
+ * Commands:
+ * Ctrl-q + q   -   Quit
+ * Ctrl-q + e   -   Local echo on/off (default off)
+ * Ctrl-q + v   -   VT52 emulation on/off (default on)
+ *
+ * TODO:
+ * Implement arrow keys (needs updated screen driver)
+ * Implement port settings (needs updated serial driver)
+ * Implement some sort of output showing current settings
+ * Implement Xon/Xoff flow control
+ * Add xmodem send/receive to allow file transfer
+*/
+ 
+#include <cpm.h>
+#include <stdio.h>
+#include "lib/serial.h"
+#include "lib/screen.h"
+
+static void cr(void) 
+{
+    cpm_printstring("\n\r");
+}
+
+static void fatal(const char* msg) 
+{
+    cpm_printstring("Error: ");
+    cpm_printstring(msg);
+    cr();
+    cpm_warmboot();
+}
+
+int main(void) 
+{
+    uint8_t inp;
+    uint8_t local_echo = 0;
+    uint8_t vt52 = 1;
+    uint8_t cur_x, cur_y;
+    uint8_t w,h,i;
+    uint8_t mEsc=0;
+    uint8_t parse=0;
+    if(!serial_init())
+        fatal("No SERIAL driver, exiting");
+
+    if(!screen_init())
+        fatal("No SCREEN driver, exiting");
+
+    // Open serial port
+    serial_open(0);
+    
+    cpm_printstring("VT52 terminal emulator - Press ctrl-q + q to quit");
+    cr();
+    
+    screen_getsize(&w, &h);
+    
+    while(1) { 
+        inp = 0;
+        // Check for data on serial port and parse it
+        inp = serial_inp();
+        parse = 1;
+        if(vt52) {        
+            if((inp >= 32) && (inp < 127)) {
+                switch(mEsc) {
+                    case 0: // Regular ASCII
+                        // TODO: Graphicsmode?
+                        cpm_conout(inp);
+                        parse = 0;
+                        break;
+                    case 1: // Escape sequence
+                        break;
+                    case 2: // Escape Y, cursor addressing
+                        mEsc = inp;
+                        parse = 0;
+                        break;
+                    default: // Second part of cursor addressing
+                        cur_x = inp - 32;
+                        cur_y = mEsc - 32;
+                        screen_setcursor(cur_x, cur_y);
+                        parse = 0;
+                        mEsc = 0;
+                        break;
+                }
+            
+            }
+            if((parse == 1) && (inp != 0)) {
+                screen_getcursor(&cur_x, &cur_y);
+                switch(inp) {
+                    case 0x0d:
+                        cur_x = 0;
+                        break;
+                    case 0x0a:
+                        cur_y++;
+                        if(cur_y > h) {
+                            cur_y = h;
+                            screen_scrollup();
+                        }
+                        
+                        break;
+                    case 0x08:
+                        cur_x--;
+                        break;
+                    case 0x09:
+                        cur_x = cur_x + 8 - (cur_x % 8);
+                        if(cur_x > w) cur_x = w;
+                        break;
+                    case 0x07:
+                        // Bell, ignore
+                        break;
+                    case 0x1b:
+                        // Escape
+                        mEsc = 1;
+                        break;
+                    case 'A':
+                        // Cursor up
+                        mEsc = 0;
+                        if(cur_y > 0) cur_y--;
+                        break;
+                    case 'B':
+                        // Cursor down
+                        mEsc = 0;
+                        if(cur_y < h) cur_y++;
+                        break;
+                    case 'C':
+                        // Cursor right
+                        mEsc = 0;
+                        if(cur_x < w) cur_x++;
+                        break;
+                    case 'D':
+                        // Cursor left
+                        mEsc = 0;
+                        if(cur_x > 0 ) cur_x--;
+                        break;
+                    case 'F':
+                        // Enter Graphics mode, ignore
+                        mEsc = 0;
+                        break;
+                    case 'G':
+                        // Exit graphics mode, ignore
+                        mEsc = 0;
+                        break;
+                    case 'H':
+                        // Cursor home
+                        mEsc = 0;
+                        cur_x = 0;
+                        cur_y = 0;
+                        break;
+                    case 'I':
+                        // Reverse line feed
+                        mEsc = 0;
+                        if(cur_y > 0)
+                            cur_y--;
+                        else {
+                            cur_y = 0;
+                            screen_scrolldown();
+                        }
+                        break;
+                    case 'J':
+                        // Erase to end of screen
+                        mEsc = 0;
+                        screen_clear_to_eol();
+                        for(i=cur_y+1; i<h; i++) {
+                            screen_setcursor(0,i);
+                            screen_clear_to_eol();
+                        }
+                        break;
+                    case 'K':
+                        // Erase to end of line
+                        mEsc = 0;
+                        screen_clear_to_eol();
+                        break;
+                    case 'Y':
+                        // Cursor addressing
+                        mEsc = 2; 
+                        break;
+                    case 'Z':
+                        // Identify terminal
+                        mEsc = 0;
+                        serial_out(0x1B);
+                        serial_out('/');
+                        serial_out('K');
+                        break;
+                    case '[':
+                        // Enter hold screen mode, ignore
+                        mEsc = 0;
+                        break;
+                    case '\\':
+                        // Exit hold screen mode, igonre
+                        mEsc = 0;
+                        break;
+                    case '=':
+                        // Enter alternate keypad mode, ignore
+                        mEsc = 0;
+                        break;
+                    case '>':
+                        // Exit alternate keypad mode, ignore
+                        mEsc = 0;
+                        break;
+                    default:
+                        if((inp >= 32) && (inp < 127)) mEsc = 0;
+                        break;
+                }
+                screen_setcursor(cur_x, cur_y);
+            }
+        } else {
+            // Raw mode
+            if(inp) cpm_conout(inp);
+        }
+        // Check for TTY input
+        if(cpm_const()) {
+            // Use cpm_bios_conin as cpm_conin crashes...
+            inp = cpm_bios_conin();
+            if(inp == 0x11) { // Ctrl+Q, check for local commands
+                inp = cpm_bios_conin();
+                switch(inp) {
+                    case 'q':
+                        // Quit
+                        cpm_warmboot();
+                        break;
+                    case 'e':
+                        // Toggle local echo
+                        if(!local_echo) local_echo = 1;
+                        else local_echo = 0;
+                        break;
+                    case 'v':
+                        // Toggle VT52 emulation
+                        if(!vt52) vt52 = 1;
+                        else vt52 = 0;
+                    default:
+                    break;
+                }
+            } else {
+                // Send data to serial port if found (echo?)
+                if(local_echo) cpm_conout(inp); // Echo
+                serial_out(inp);
+            }
+        }
+    }   
+}

--- a/apps/vt52term.c
+++ b/apps/vt52term.c
@@ -53,8 +53,11 @@ int main(void)
     uint8_t inp;
     uint8_t local_echo = 0;
     uint8_t vt52 = 1;
-    uint8_t cur_x, cur_y;
-    uint8_t w,h,i;
+    uint8_t cur_x;
+    uint8_t cur_y;
+    uint8_t w;
+    uint8_t h;
+    uint8_t i;
     uint8_t mEsc=0;
     uint8_t parse=0;
     if(!serial_init())
@@ -76,12 +79,15 @@ int main(void)
         // Check for data on serial port and parse it
         inp = serial_inp();
         parse = 1;
-        if(vt52) {        
+        if(vt52) {
+            screen_getcursor(&cur_x, &cur_y);
             if((inp >= 32) && (inp < 127)) {
                 switch(mEsc) {
                     case 0: // Regular ASCII
-                        // TODO: Graphicsmode?
-                        cpm_conout(inp);
+                        screen_putchar(inp);
+                        cur_x++;
+                        if(cur_x > w) cur_x = 0;
+                        screen_setcursor(cur_x,cur_y);
                         parse = 0;
                         break;
                     case 1: // Escape sequence
@@ -101,7 +107,6 @@ int main(void)
             
             }
             if((parse == 1) && (inp != 0)) {
-                screen_getcursor(&cur_x, &cur_y);
                 switch(inp) {
                     case CR:
                         cur_x = 0;
@@ -231,15 +236,18 @@ int main(void)
                 inp = cpm_bios_conin();
                 switch(inp) {
                     case 'q':
+                    case 'Q':
                         // Quit
                         cpm_warmboot();
                         break;
                     case 'e':
+                    case 'E':
                         // Toggle local echo
                         if(!local_echo) local_echo = 1;
                         else local_echo = 0;
                         break;
                     case 'v':
+                    case 'V':
                         // Toggle VT52 emulation
                         if(!vt52) vt52 = 1;
                         else vt52 = 0;

--- a/apps/vt52term.c
+++ b/apps/vt52term.c
@@ -4,7 +4,9 @@
  *
  * A VT52 terminal emulator for CP/M-65. Works well enough to login and run
  * vim on a linux server (if the shell is configured correctly for VT52).
- * Requires SCREEN and SERIAL drivers.
+ * Xmodem file transfer using sx on linux works.
+ *
+ * Requires SERIAL driver. SCREEN driver needed for VT52 emulation.
  * 
  * VT52 parsing code heavily inspired by Kenneth Gobers VT52 terminal emulator for 
  * windows, see https://github.com/kgober/VT52/
@@ -12,13 +14,14 @@
  * Commands:
  * Ctrl-q + q   -   Quit
  * Ctrl-q + e   -   Local echo on/off (default off)
- * Ctrl-q + v   -   VT52 emulation on/off (default on)
+ * Ctrl-q + v   -   VT52 emulation on/off (default on if SCREEN driver available)
+ * Ctrl-q + r   -   Xmodem receive
  *
  * TODO:
- * Implement arrow keys (needs updated screen driver)
+ * Implement sending VT52 sequences for arrow keys (needs updated screen driver)
  * Implement port settings (needs updated serial driver)
- * Implement some sort of output showing current settings
- * Implement Xon/Xoff flow control
+ * Implement Xmodem send
+ * Implement XON/XOFF flow control (or should it be handled by the driver?)
  * Add xmodem send/receive to allow file transfer
 */
  
@@ -34,6 +37,175 @@
 #define CR          0x0d
 #define LF          0x0a
 #define LOCAL_CMD   0x11   // ctrl+q
+#define SOH         0x01
+#define EOT         0x04
+#define ACK         0x06
+#define DLE         0x10
+#define XON         0x11
+#define XOFF        0x13
+#define NAK         0x15
+#define SYN         0x16
+#define CAN         0x18
+#define SUB         0x1a
+
+static uint8_t mEsc = 0;
+static uint8_t w;
+static uint8_t h;
+
+static FCB xmodem_file;
+static uint8_t xmodem_buffer[128]; 
+
+static void vt52_parse(uint8_t inp) {
+    uint8_t parse;
+    uint8_t cur_x;
+    uint8_t cur_y;  
+    uint8_t i;  
+    parse = 1;
+    screen_getcursor(&cur_x, &cur_y);
+    
+    if((inp >= 32) && (inp < 127)) {
+        switch(mEsc) {
+            case 0: // Regular ASCII
+                screen_putchar(inp);
+                cur_x++;
+                if(cur_x > w) cur_x = 0;
+                    screen_setcursor(cur_x,cur_y);
+                    parse = 0;
+                    break;
+                case 1: // Escape sequence
+                    break;
+                case 2: // Escape Y, cursor addressing
+                    mEsc = inp;
+                    parse = 0;
+                    break;
+                default: // Second part of cursor addressing
+                    cur_x = inp - 32;
+                    cur_y = mEsc - 32;
+                    screen_setcursor(cur_x, cur_y);
+                    parse = 0;
+                    mEsc = 0;
+                    break;
+        }
+    }
+    
+    if((parse == 1) && (inp != 0)) {
+        switch(inp) {
+            case CR:
+                cur_x = 0;
+                break;
+            case LF:
+                cur_y++;
+                if(cur_y > h) {
+                    cur_y = h;
+                    screen_scrollup();
+                }
+                break;
+            case BACKSPACE:
+                cur_x--;
+                break;
+            case TAB:
+                cur_x = cur_x + 8 - (cur_x % 8);
+                if(cur_x > w) cur_x = w;
+                break;
+            case BELL:
+                // Bell, ignore
+                break;
+            case ESC:
+                // Escape
+                mEsc = 1;
+                break;
+            case 'A':
+                // Cursor up
+                mEsc = 0;
+                if(cur_y > 0) cur_y--;
+                break;
+            case 'B':
+                // Cursor down
+                mEsc = 0;
+                if(cur_y < h) cur_y++;
+                break;
+            case 'C':
+                // Cursor right
+                mEsc = 0;
+                if(cur_x < w) cur_x++;
+                break;
+            case 'D':
+                // Cursor left
+                mEsc = 0;
+                if(cur_x > 0 ) cur_x--;
+                break;
+            case 'F':
+                // Enter Graphics mode, ignore
+                mEsc = 0;
+                break;
+            case 'G':
+                // Exit graphics mode, ignore
+                mEsc = 0;
+                break;
+            case 'H':
+                // Cursor home
+                mEsc = 0;
+                cur_x = 0;
+                cur_y = 0;
+                break;
+            case 'I':
+                // Reverse line feed
+                mEsc = 0;
+                if(cur_y > 0)
+                    cur_y--;
+                else {
+                    cur_y = 0;
+                    screen_scrolldown();
+                }
+                break;
+            case 'J':
+                // Erase to end of screen
+                mEsc = 0;
+                screen_clear_to_eol();
+                for(i=cur_y+1; i<h; i++) {
+                    screen_setcursor(0,i);
+                    screen_clear_to_eol();
+                }
+                break;
+            case 'K':
+                // Erase to end of line
+                mEsc = 0;
+                screen_clear_to_eol();
+                break;
+            case 'Y':
+                // Cursor addressing
+                mEsc = 2; 
+                break;
+            case 'Z':
+                // Identify terminal
+                mEsc = 0;
+                serial_out(0x1B);
+                serial_out('/');
+                serial_out('K');
+                break;
+            case '[':
+                // Enter hold screen mode, ignore
+                mEsc = 0;
+                break;
+            case '\\':
+                // Exit hold screen mode, igonre
+                mEsc = 0;
+                break;
+            case '=':
+                // Enter alternate keypad mode, ignore
+                mEsc = 0;
+                break;
+            case '>':
+                // Exit alternate keypad mode, ignore
+                mEsc = 0;
+                break;
+            default:
+                if((inp >= 32) && (inp < 127)) mEsc = 0;
+                break;
+        }
+        screen_setcursor(cur_x, cur_y);
+    }
+}
 
 static void cr(void) 
 {
@@ -48,185 +220,136 @@ static void fatal(const char* msg)
     cpm_warmboot();
 }
 
+static uint8_t getblockchar(uint8_t *data) {
+    uint8_t data_available;
+    uint16_t i;
+    for(i=0; i<30000; i++) {
+        serial_inp(data, &data_available);
+        if(data_available) break;
+    }
+    return data_available;
+}
+
+static void xmodem_receive(void) {
+    char filename_input[14];
+    uint8_t block_cnt = 0;
+    uint8_t pos = 0;
+    uint8_t checksum;
+    uint8_t delay_1;
+    uint8_t inp;
+    uint8_t outp;
+    uint8_t data_available;
+    cpm_printstring("X modem receive");
+    cr();
+    cpm_printstring("Enter filename: ");
+
+    filename_input[0]=11;
+    filename_input[1]=0;    
+    cpm_readline((uint8_t *)filename_input);
+    cr();
+
+    // Parse filename
+    cpm_set_dma(&xmodem_file);
+    if(!cpm_parse_filename(&filename_input[2])) {
+        cpm_printstring("Bad filename\r\n");
+        return;
+    }
+
+    // Create file
+    if(cpm_make_file( &xmodem_file)) {
+        cpm_printstring("Error creating file\r\n");
+        return;
+    }
+
+    delay_1 = 0;
+    outp = NAK;
+    // Transmission
+    while(1) {
+        serial_out(outp);
+        if(getblockchar(&inp)) {
+            if(inp == EOT) {
+                cpm_printstring("Transmission done");
+                cr();
+                cpm_close_file(&xmodem_file);
+                return;
+            }
+            if(inp == CAN) {
+                cpm_printstring("Transmission cancelled");
+                cr();
+                cpm_close_file(&xmodem_file);
+                return;
+            }
+            if(inp == SOH) {
+                // Got header, get package
+                outp = NAK;
+                checksum = 0;
+                getblockchar(&inp);
+                block_cnt = inp;
+                getblockchar(&inp);
+                if(block_cnt == (inp ^ 0xFF)) {
+                    // Get block, otherwise retry
+                    for(pos=0; pos<128; pos++) {
+                        getblockchar(&inp);
+                        xmodem_buffer[pos]=inp;
+                        checksum += inp;                    
+                    }
+                    // Verify checksum
+                    getblockchar(&inp);
+                    if(checksum == inp) {
+                        outp = ACK;
+                        cpm_set_dma(&xmodem_buffer);
+                        cpm_write_sequential(&xmodem_file);    
+                    }
+                }
+            } 
+        }
+        delay_1++;
+        cpm_conout('.');
+        if(delay_1 == 200) {
+            cpm_close_file(&xmodem_file);
+            cpm_printstring("Timeout");
+            cr();
+            return;
+        }
+    }
+
+}
+
 int main(void) 
 {
     uint8_t inp;
+    uint8_t data_available;
     uint8_t local_echo = 0;
     uint8_t vt52 = 1;
-    uint8_t cur_x;
-    uint8_t cur_y;
-    uint8_t w;
-    uint8_t h;
-    uint8_t i;
-    uint8_t mEsc=0;
-    uint8_t parse=0;
+    uint8_t screen_available = 1;
     if(!serial_init())
         fatal("No SERIAL driver, exiting");
 
-    if(!screen_init())
-        fatal("No SCREEN driver, exiting");
-
+    if(!screen_init()) {
+        cpm_printstring("No SCREEN driver, VT52 mode disabled");
+        cr();
+        vt52 = 0;
+        screen_available = 0;
+    }
     // Open serial port
     serial_open(0);
     
-    cpm_printstring("VT52 terminal emulator - Press ctrl-q + q to quit");
+    cpm_printstring("VT52 terminal emulator");
+    cr();
+    cpm_printstring("Press ctrl-q + h for help");
     cr();
     
-    screen_getsize(&w, &h);
+    if(screen_available) screen_getsize(&w, &h);
     
     while(1) { 
         inp = 0;
         // Check for data on serial port and parse it
-        inp = serial_inp();
-        parse = 1;
-        if(vt52) {
-            screen_getcursor(&cur_x, &cur_y);
-            if((inp >= 32) && (inp < 127)) {
-                switch(mEsc) {
-                    case 0: // Regular ASCII
-                        screen_putchar(inp);
-                        cur_x++;
-                        if(cur_x > w) cur_x = 0;
-                        screen_setcursor(cur_x,cur_y);
-                        parse = 0;
-                        break;
-                    case 1: // Escape sequence
-                        break;
-                    case 2: // Escape Y, cursor addressing
-                        mEsc = inp;
-                        parse = 0;
-                        break;
-                    default: // Second part of cursor addressing
-                        cur_x = inp - 32;
-                        cur_y = mEsc - 32;
-                        screen_setcursor(cur_x, cur_y);
-                        parse = 0;
-                        mEsc = 0;
-                        break;
-                }
-            
-            }
-            if((parse == 1) && (inp != 0)) {
-                switch(inp) {
-                    case CR:
-                        cur_x = 0;
-                        break;
-                    case LF:
-                        cur_y++;
-                        if(cur_y > h) {
-                            cur_y = h;
-                            screen_scrollup();
-                        }
-                        
-                        break;
-                    case BACKSPACE:
-                        cur_x--;
-                        break;
-                    case TAB:
-                        cur_x = cur_x + 8 - (cur_x % 8);
-                        if(cur_x > w) cur_x = w;
-                        break;
-                    case BELL:
-                        // Bell, ignore
-                        break;
-                    case ESC:
-                        // Escape
-                        mEsc = 1;
-                        break;
-                    case 'A':
-                        // Cursor up
-                        mEsc = 0;
-                        if(cur_y > 0) cur_y--;
-                        break;
-                    case 'B':
-                        // Cursor down
-                        mEsc = 0;
-                        if(cur_y < h) cur_y++;
-                        break;
-                    case 'C':
-                        // Cursor right
-                        mEsc = 0;
-                        if(cur_x < w) cur_x++;
-                        break;
-                    case 'D':
-                        // Cursor left
-                        mEsc = 0;
-                        if(cur_x > 0 ) cur_x--;
-                        break;
-                    case 'F':
-                        // Enter Graphics mode, ignore
-                        mEsc = 0;
-                        break;
-                    case 'G':
-                        // Exit graphics mode, ignore
-                        mEsc = 0;
-                        break;
-                    case 'H':
-                        // Cursor home
-                        mEsc = 0;
-                        cur_x = 0;
-                        cur_y = 0;
-                        break;
-                    case 'I':
-                        // Reverse line feed
-                        mEsc = 0;
-                        if(cur_y > 0)
-                            cur_y--;
-                        else {
-                            cur_y = 0;
-                            screen_scrolldown();
-                        }
-                        break;
-                    case 'J':
-                        // Erase to end of screen
-                        mEsc = 0;
-                        screen_clear_to_eol();
-                        for(i=cur_y+1; i<h; i++) {
-                            screen_setcursor(0,i);
-                            screen_clear_to_eol();
-                        }
-                        break;
-                    case 'K':
-                        // Erase to end of line
-                        mEsc = 0;
-                        screen_clear_to_eol();
-                        break;
-                    case 'Y':
-                        // Cursor addressing
-                        mEsc = 2; 
-                        break;
-                    case 'Z':
-                        // Identify terminal
-                        mEsc = 0;
-                        serial_out(0x1B);
-                        serial_out('/');
-                        serial_out('K');
-                        break;
-                    case '[':
-                        // Enter hold screen mode, ignore
-                        mEsc = 0;
-                        break;
-                    case '\\':
-                        // Exit hold screen mode, igonre
-                        mEsc = 0;
-                        break;
-                    case '=':
-                        // Enter alternate keypad mode, ignore
-                        mEsc = 0;
-                        break;
-                    case '>':
-                        // Exit alternate keypad mode, ignore
-                        mEsc = 0;
-                        break;
-                    default:
-                        if((inp >= 32) && (inp < 127)) mEsc = 0;
-                        break;
-                }
-                screen_setcursor(cur_x, cur_y);
-            }
+        serial_inp(&inp, &data_available);
+        if(vt52 && data_available) {
+            vt52_parse(inp); 
         } else {
             // Raw mode
-            if(inp) cpm_conout(inp);
+            if(data_available) cpm_conout(inp);
         }
         // Check for TTY input
         if(cpm_const()) {
@@ -238,19 +361,55 @@ int main(void)
                     case 'q':
                     case 'Q':
                         // Quit
+                        cpm_printstring("Goodbye!");
+                        cr();
                         cpm_warmboot();
                         break;
                     case 'e':
                     case 'E':
                         // Toggle local echo
-                        if(!local_echo) local_echo = 1;
-                        else local_echo = 0;
+                        cpm_printstring("Local echo ");
+                        if(!local_echo) {
+                            local_echo = 1;
+                            cpm_printstring("ON");
+                        } else { 
+                            local_echo = 0;
+                            cpm_printstring("OFF");
+                        }
+                        cr();
                         break;
                     case 'v':
                     case 'V':
                         // Toggle VT52 emulation
-                        if(!vt52) vt52 = 1;
-                        else vt52 = 0;
+                        cpm_printstring("VT52 emulation ");
+                        if(!vt52 && screen_available) {
+                            vt52 = 1;
+                            cpm_printstring("ON");
+                        } else { 
+                            vt52 = 0;
+                            cpm_printstring("OFF");
+                        }
+                        cr();
+                        break;
+                    case 'r':
+                    case 'R':
+                        // Xmodem receive;
+                        xmodem_receive();
+                        break;
+                    case 'h':
+                    case 'H':
+                        // Print help
+                        cpm_printstring("Available commands:");
+                        cr();
+                        cpm_printstring("Ctrl-q + q:    Quit");
+                        cr();
+                        cpm_printstring("Ctrl-q + e:    Toggle local echo");
+                        cr();
+                        cpm_printstring("Ctrl-q + v:    Toggle VT52 emulation");
+                        cr();
+                        cpm_printstring("Ctrl-q + r:    Xmodem Receive");
+                        cr();
+                        break;
                     default:
                     break;
                 }

--- a/apps/vt52term.c
+++ b/apps/vt52term.c
@@ -365,6 +365,7 @@ int main(void)
                         // Quit
                         cpm_printstring("Goodbye!");
                         cr();
+                        serial_close();
                         cpm_warmboot();
                         break;
                     case 'e':

--- a/apps/vt52term.c
+++ b/apps/vt52term.c
@@ -4,12 +4,14 @@
  *
  * A VT52 terminal emulator for CP/M-65. Works well enough to login and run
  * vim on a linux server (if the shell is configured correctly for VT52).
- * Xmodem file transfer using sx on linux works.
+ * Xmodem file transfer during a session using sx on linux works.
  *
  * Requires SERIAL driver. SCREEN driver needed for VT52 emulation.
  * 
  * VT52 parsing code heavily inspired by Kenneth Gobers VT52 terminal emulator for 
  * windows, see https://github.com/kgober/VT52/
+ *
+ * Xmodem code heavily inspired by xrecv.asm
  *
  * Commands:
  * Ctrl-q + q   -   Quit
@@ -235,7 +237,7 @@ static void xmodem_receive(void) {
     uint8_t block_cnt = 0;
     uint8_t pos = 0;
     uint8_t checksum;
-    uint8_t delay_1;
+    uint8_t delay;
     uint8_t inp;
     uint8_t outp;
     uint8_t data_available;
@@ -261,7 +263,7 @@ static void xmodem_receive(void) {
         return;
     }
 
-    delay_1 = 0;
+    delay = 0;
     outp = NAK;
     // Transmission
     while(1) {
@@ -303,9 +305,9 @@ static void xmodem_receive(void) {
                 }
             } 
         }
-        delay_1++;
+        delay++;
         cpm_conout('.');
-        if(delay_1 == 200) {
+        if(delay == 200) {
             cpm_close_file(&xmodem_file);
             cpm_printstring("Timeout");
             cr();
@@ -414,8 +416,8 @@ int main(void)
                     break;
                 }
             } else {
-                // Send data to serial port if found (echo?)
-                if(local_echo) cpm_conout(inp); // Echo
+                // Send data to serial port and echo if avtivated
+                if(local_echo) cpm_conout(inp);
                 serial_out(inp);
             }
         }

--- a/apps/vt52term.c
+++ b/apps/vt52term.c
@@ -300,7 +300,8 @@ static void xmodem_receive(void) {
                     if(checksum == inp) {
                         outp = ACK;
                         cpm_set_dma(&xmodem_buffer);
-                        cpm_write_sequential(&xmodem_file);    
+                        cpm_write_sequential(&xmodem_file);
+                        if(delay > 0) delay--;    
                     }
                 }
             } 

--- a/apps/vt52test.asm
+++ b/apps/vt52test.asm
@@ -1,0 +1,218 @@
+\ Screen driver tester for CP/M-65 - Copyright (C) 2023 Henrik Lofgren
+\ This file is licensed under the terms of the 2-clause BSD license. Please
+\ see the COPYING file in the root project directory for the full text.
+
+.include "cpm65.inc"
+.include "drivers.inc"
+
+.expand 1
+
+.label string_init
+.label string_up
+.label string_down
+.label string_right
+.label string_left
+.label string_home
+.label string_rev_lf
+.label string_cl_end
+.label string_cl_line
+.label string_cur_addr 
+
+.zproc start
+
+help:
+    \ Print help
+    lda #<string_init
+    ldx #>string_init
+    ldy #BDOS_PRINTSTRING
+    jsr BDOS
+
+mainloop:
+    \ Get and parse command
+    ldx #0xfd
+    ldy #BDOS_CONIO
+    jsr BDOS
+    
+    \ Convert to uppercase
+    cmp #0x61
+    bcc case_done
+    cmp #0x7a
+    bcs case_done
+    sec
+    sbc #0x20    
+
+case_done:
+    \ Cursor left
+    cmp #'A'
+    .zif eq
+        lda #<string_left
+        ldx #>string_left
+        ldy #BDOS_PRINTSTRING
+        jsr BDOS
+        jmp mainloop
+    .zendif
+    
+    \ Cursor right
+    cmp #'D'
+    .zif eq
+        lda #<string_right
+        ldx #>string_right
+        ldy #BDOS_PRINTSTRING
+        jsr BDOS
+        jmp mainloop
+    .zendif
+   
+    \ Cursor up 
+    cmp #'W'
+    .zif eq
+        lda #<string_up
+        ldx #>string_up
+        ldy #BDOS_PRINTSTRING
+        jsr BDOS
+        jmp mainloop
+    .zendif
+   
+    \ Cursor down 
+    cmp #'S'
+    .zif eq
+        lda #<string_down
+        ldx #>string_down
+        ldy #BDOS_PRINTSTRING
+        jsr BDOS
+        jmp mainloop
+    .zendif
+
+    \ Cursor home
+    cmp #'H'
+    .zif eq
+        lda #<string_home
+        ldx #>string_home
+        ldy #BDOS_PRINTSTRING
+        jsr BDOS
+        jmp mainloop
+    .zendif
+
+    \ Reverse linefeed
+    cmp #'I'
+    .zif eq
+        lda #<string_rev_lf
+        ldx #>string_rev_lf
+        ldy #BDOS_PRINTSTRING
+        jsr BDOS
+        jmp mainloop
+    .zendif
+
+    \ Clear to end of screen
+    cmp #'J'
+    .zif eq
+        lda #<string_cl_end
+        ldx #>string_cl_end
+        ldy #BDOS_PRINTSTRING
+        jsr BDOS
+        jmp mainloop
+    .zendif
+
+    \ Clear to end of line
+    cmp #'K'
+    .zif eq
+        lda #<string_cl_line
+        ldx #>string_cl_line
+        ldy #BDOS_PRINTSTRING
+        jsr BDOS
+        jmp mainloop
+    .zendif
+
+    \ Cursor addressing
+    cmp #'Y'
+    .zif eq
+        lda #<string_cur_addr
+        ldx #>string_cur_addr
+        ldy #BDOS_PRINTSTRING
+        jsr BDOS
+        jmp mainloop
+    .zendif
+
+    \ Tab
+    cmp #'T'
+    .zif eq
+        lda #0x09
+        ldy #BDOS_CONOUT
+        jsr BDOS
+        jmp mainloop
+    .zendif
+
+    \ Backspace
+    cmp #'B'
+    .zif eq
+        lda #0x08
+        ldy #BDOS_CONOUT
+        jsr BDOS
+        jmp mainloop
+    .zendif
+  
+    \ CR
+    cmp #'C'
+    .zif eq
+        lda #0x0d
+        ldy #BDOS_CONOUT
+        jsr BDOS
+        jmp mainloop
+    .zendif
+    
+    \ LF
+    cmp #'L'
+    .zif eq
+        lda #0x0a
+        ldy #BDOS_CONOUT
+        jsr BDOS
+        jmp mainloop
+    .zendif
+
+    \ Print help 
+    cmp #'P'
+    beq help
+
+    \ Quit 
+    cmp #'Q'
+    .zif eq
+        rts
+    .zendif
+    
+    jmp mainloop
+.zendproc
+
+string_init:
+    .byte "CP/M-65 VT52 driver tester\r\n\r\n"
+    .byte "W,A,S,D - Move cursor\r\n"
+    .byte "H - Cursor home\r\n"
+    .byte "I - Reverse linefeed\r\n"
+    .byte "J - Clear to end of screen\r\n"
+    .byte "K - Clear to end of line\r\n"
+    .byte "Y - Cursor addressing\r\n"
+    .byte "T - Tab\r\n"
+    .byte "B - Backspace\r\n"
+    .byte "C - Carriage return\r\n"
+    .byte "L - Linefeed\r\n"
+    .byte "P - Print this help\r\n"
+    .byte "Q - Quit\r\n"
+    .byte 0
+
+string_up:
+    .byte 27,'A',0
+string_down:
+    .byte 27,'B',0
+string_right:
+    .byte 27,'C',0
+string_left:
+    .byte 27,'D',0
+string_home:
+    .byte 27,'H',0
+string_rev_lf:
+    .byte 27,'I',0
+string_cl_end:
+    .byte 27,'J',0
+string_cl_line:
+    .byte 27,'K',0
+string_cur_addr:
+    .byte 27,'Y',46,63,0
+

--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ SCREEN_APPS = {
     "0:cls.com": "apps+cls",
     "0:life.com": "apps+life",
     "0:qe.com": "apps+qe",
+    "0:vt52term.com": "apps+vt52term",
 }
 
 SCREEN_APPS_SRCS = {"0:cls.asm": "apps/cls.asm"}

--- a/config.py
+++ b/config.py
@@ -24,7 +24,7 @@ BIG_APPS = {
     "0:atbasic.com": "third_party/altirrabasic",
     "0:objdump.com": "apps+objdump",
     "0:scrntest.com": "apps+scrntest",
-    "0:vt52term.com": "apps+vt52term",    
+    "0:vt52term.com": "apps+vt52term",
 }
 
 BIG_APPS_SRCS = {}
@@ -33,6 +33,8 @@ SCREEN_APPS = {
     "0:cls.com": "apps+cls",
     "0:life.com": "apps+life",
     "0:qe.com": "apps+qe",
+    "0:vt52drv.com": "apps+vt52drv",
+    "0:vt52test.com": "apps+vt52test",
 }
 
 SCREEN_APPS_SRCS = {"0:cls.asm": "apps/cls.asm"}

--- a/config.py
+++ b/config.py
@@ -24,6 +24,7 @@ BIG_APPS = {
     "0:atbasic.com": "third_party/altirrabasic",
     "0:objdump.com": "apps+objdump",
     "0:scrntest.com": "apps+scrntest",
+    "0:vt52term.com": "apps+vt52term",    
 }
 
 BIG_APPS_SRCS = {}
@@ -32,7 +33,6 @@ SCREEN_APPS = {
     "0:cls.com": "apps+cls",
     "0:life.com": "apps+life",
     "0:qe.com": "apps+qe",
-    "0:vt52term.com": "apps+vt52term",
 }
 
 SCREEN_APPS_SRCS = {"0:cls.asm": "apps/cls.asm"}

--- a/lib/build.py
+++ b/lib/build.py
@@ -5,7 +5,8 @@ llvmclibrary(name="xfcb", srcs=["./xfcb.S"], deps=["include"])
 
 llvmclibrary(
     name="cpm65",
-    srcs=["./printi.S", "./screen.S"],
-    hdrs={"lib/printi.h": "./printi.h", "lib/screen.h": "./screen.h"},
+    srcs=["./printi.S", "./screen.S", "./serial.S"],
+    hdrs={"lib/printi.h": "./printi.h", "lib/screen.h": "./screen.h", 
+	  "lib/serial.h": "./serial.h"},
     deps=["include"],
 )

--- a/lib/screen.S
+++ b/lib/screen.S
@@ -53,6 +53,16 @@ zproc screen_putstring, .text.screen_putstring
     jmp _call_screen
 zendproc
 
+zproc screen_scrollup, text.screen_scrollup
+    ldy #SCREEN_SCROLLUP
+    jmp _call_screen
+zendproc
+
+zproc screen_scrolldown, text.screen_scrolldown
+    ldy #SCREEN_SCROLLDOWN
+    jmp _call_screen
+zendproc
+
 zproc screen_clear_to_eol, .text.screen_clear_to_eol
     ldy #SCREEN_CLEARTOEOL
     jmp _call_screen

--- a/lib/screen.S
+++ b/lib/screen.S
@@ -53,12 +53,12 @@ zproc screen_putstring, .text.screen_putstring
     jmp _call_screen
 zendproc
 
-zproc screen_scrollup, text.screen_scrollup
+zproc screen_scrollup, .text.screen_scrollup
     ldy #SCREEN_SCROLLUP
     jmp _call_screen
 zendproc
 
-zproc screen_scrolldown, text.screen_scrolldown
+zproc screen_scrolldown, .text.screen_scrolldown
     ldy #SCREEN_SCROLLDOWN
     jmp _call_screen
 zendproc

--- a/lib/screen.h
+++ b/lib/screen.h
@@ -11,6 +11,8 @@ extern void screen_putchar(char c);
 extern void screen_putstring(const char* s);
 extern uint16_t screen_getchar(uint16_t timeout_cs);
 extern uint8_t screen_waitchar(void);
+extern void screen_scrollup(void);
+extern void screen_scrolldown(void);
 extern void screen_clear_to_eol(void);
 extern void screen_setstyle(uint8_t style);
 

--- a/lib/serial.S
+++ b/lib/serial.S
@@ -1,0 +1,55 @@
+; CP/M-65 Copyright © 2023 David Given
+; This file is licensed under the terms of the 2-clause BSD license. Please
+; see the COPYING file in the root project directory for the full text.
+
+#include "cpm65.inc"
+#include "driver.inc"
+#include "zif.inc"
+
+zproc _call_serial, .text._call_serial
+    jmp 0
+zendproc
+
+zproc serial_init, .text.screen_init
+    lda #<DRVID_SERIAL
+    ldx #>DRVID_SERIAL
+    ldy #BIOS_FINDDRV
+    jsr BIOS
+    sta _call_serial+1
+    stx _call_serial+2
+    lda #0
+    ror a
+    eor #0x80
+    rts
+zendproc
+
+zproc serial_open, .text.serial_open
+    ldy #SERIAL_OPEN
+    jmp _call_serial
+zendproc
+
+zproc serial_close, .text.serial_close
+    ldy #SERIAL_CLOSE
+    jmp _call_serial
+zendproc
+
+zproc serial_inp, .text.serial_inp
+    ldy #SERIAL_INP
+    jmp _call_serial
+zendproc
+
+zproc serial_out, .text.serial_out
+    ldy #SERIAL_OUT
+    jmp _call_serial
+zendproc
+
+zproc serial_outp, .text.serial_outp
+    ldy #SERIAL_OUTP
+    jmp _call_serial
+zendproc
+
+zproc serial_in, .text.serial_in
+    ldy #SERIAL_IN
+    jmp _call_serial
+zendproc
+

--- a/lib/serial.S
+++ b/lib/serial.S
@@ -33,9 +33,15 @@ zproc serial_close, .text.serial_close
     jmp _call_serial
 zendproc
 
-zproc serial_inp, .text.serial_inp
+zproc _serial_inp, .text._serial_inp
     ldy #SERIAL_INP
-    jmp _call_serial
+    jsr _call_serial
+    zif_cs
+        ldx #0
+        rts
+    zendif
+    ldx #1
+    rts
 zendproc
 
 zproc serial_out, .text.serial_out

--- a/lib/serial.h
+++ b/lib/serial.h
@@ -1,0 +1,13 @@
+#ifndef SERIAL_H
+#define SERIAL_H
+
+extern uint8_t serial_init(void);
+extern void serial_open(uint16_t flags);
+extern void serial_close(void);
+extern uint8_t serial_inp(void);
+extern void serial_out(uint8_t c);
+extern uint8_t serial_outp(uint8_t c);
+extern uint8_t serial_in(void); 
+
+#endif
+

--- a/lib/serial.h
+++ b/lib/serial.h
@@ -4,10 +4,19 @@
 extern uint8_t serial_init(void);
 extern void serial_open(uint16_t flags);
 extern void serial_close(void);
-extern uint8_t serial_inp(void);
+extern uint16_t _serial_inp(void);
+//extern uint8_t serial_inp(uint16_t c);
 extern void serial_out(uint8_t c);
 extern uint8_t serial_outp(uint8_t c);
 extern uint8_t serial_in(void); 
+
+#define serial_inp(dp, ap) \
+    do { \
+        uint16_t c = _serial_inp(); \
+        *(dp) = c & 0xff; \
+        *(ap) = c >> 8; \
+    } while(0)
+         
 
 #endif
 

--- a/lib/serial.h
+++ b/lib/serial.h
@@ -5,7 +5,6 @@ extern uint8_t serial_init(void);
 extern void serial_open(uint16_t flags);
 extern void serial_close(void);
 extern uint16_t _serial_inp(void);
-//extern uint8_t serial_inp(uint16_t c);
 extern void serial_out(uint8_t c);
 extern uint8_t serial_outp(uint8_t c);
 extern uint8_t serial_in(void); 


### PR DESCRIPTION
I wrote a small terminal emulator CP/M-65 with VT52 emulation and Xmodem file send and receive functionality. It works well enough to login to a linux machine and run vim (when the shell is properly setup for VT52 and the correct numbers of lines and columns), and it is possible to do in-session file transfer to and from the linux machine to the CP/M-65 machine using sx/rx on the linux side.

It would be handy with defined constants for arrow keys in the screen driver to allow sending arrow-keys over VT52 instead of manually punching ESC-A to get the previous command ;)

I made a small wrapper function for serial_inp in order to allow checking if there is available data, and still accepting 0x00 as valid data, from C. Otherwise I just made a straight mapping to all functions in the serial driver.

A known issue is that files are sometimes corrupted in both directions if several Xmodem transfers are made sequentially, I am currently looking into that.

I added a vt52driver (+ a tester application) as suggested by @ivop so that other applications also can use the vt52 capability.