### PR TITLE
on Sorbus set corrent end of RAM

### DIFF
--- a/src/arch/sorbus/sorbus.S
+++ b/src/arch/sorbus/sorbus.S
@@ -465,7 +465,7 @@ zp_end:     .byte __USERZEROPAGE_END__
 ; subtract $0f00 bytes, that bdos wants to map
 ; BDOS is already fixed at $e800
 mem_base:   .byte  $02-$0f
-mem_end:    .byte  $c0
+mem_end:    .byte  $d0
 
 ; DPH for drive 0 (our only drive)
 


### PR DESCRIPTION
For some reason, the end of RAM was set to $C000. However on the hardware RAM is up to $D000, so that's fixed here.