### PR TITLE
Fix in vt52drv to ignore invalid escape sequences

### DIFF
--- a/apps/vt52drv.asm
+++ b/apps/vt52drv.asm
@@ -242,22 +242,6 @@ driver:
                 jmp par_done
             .zendif
 
-            cmp #'F'
-            .zif eq
-                \ Enter graphics mode, ignore
-                lda #0
-                sta mEsc
-                jmp par_done
-            .zendif
-        
-            cmp #'G'
-            .zif eq
-                \ Exit graphics mode, ignore
-                lda #0
-                sta mEsc
-                jmp par_done
-            .zendif
-            
             cmp #'H'
             .zif eq
                 \ Cursor home
@@ -331,8 +315,8 @@ driver:
             .zendif
 
             \ Not a valid escape sequence
-            \ Also covers not implemented sequences for screen mode and
-            \ alternate keypad mode
+            \ Also covers not implemented sequences for graphics mode,
+            \ hold screen mode and alternate keypad mode
             lda #0
             sta mEsc
 

--- a/apps/vt52drv.asm
+++ b/apps/vt52drv.asm
@@ -330,38 +330,11 @@ driver:
                 jmp par_done
             .zendif
 
-            cmp #'['
-            .zif eq
-                \ Enter hold screen mode, ignore
-                lda #0
-                sta mEsc
-                jmp par_done
-            .zendif
- 
-            cmp #'\\'
-            .zif eq
-                \ Exit hold screen mode, ignore
-                lda #0
-                sta mEsc
-                jmp par_done
-            .zendif
- 
-            cmp #'='
-            .zif eq
-                \ Enter alternate keypad mode, ignore
-                lda #0
-                sta mEsc
-                jmp par_done
-            .zendif
- 
-            cmp #'>'
-            .zif eq
-                \ Exit alternate keypad mode, ignore
-                lda #0
-                sta mEsc
-                jmp par_done
-            .zendif
- 
+            \ Not a valid escape sequence
+            \ Also covers not implemented sequences for screen more and
+            \ alternate keypad mode
+            lda #0
+            sta mEsc
 
             par_done:
             lda cur_x

--- a/apps/vt52drv.asm
+++ b/apps/vt52drv.asm
@@ -331,7 +331,7 @@ driver:
             .zendif
 
             \ Not a valid escape sequence
-            \ Also covers not implemented sequences for screen more and
+            \ Also covers not implemented sequences for screen mode and
             \ alternate keypad mode
             lda #0
             sta mEsc


### PR DESCRIPTION
Fix that prevents the vt52 driver from getting stuck when an invalid escape sequence is entered.

Fixes #107.
