### PR TITLE
Modified the dir command to print the number of filenames which fits on each line

### DIFF
--- a/src/ccp.S
+++ b/src/ccp.S
@@ -4,6 +4,7 @@
 #include "cpm65.inc"
 #include "zif.inc"
 #include "jumptables.inc"
+#include "driver.inc"
 
 ZEROPAGE
 
@@ -300,6 +301,9 @@ zproc entry_DIR
     txa
     jsr bdos_SELECTDISK
 
+    ; Find number of files to print per line
+    jsr set_dirlen
+
     ; Start iterating.
 
     lda #0
@@ -345,7 +349,7 @@ zproc entry_DIR
             txa
             inx
             stx file_counter
-            and #$01
+            cmp #$00
             zif_eq
                 jsr bdos_GETDRIVE
                 clc
@@ -368,9 +372,11 @@ zproc entry_DIR
             jsr print_filename_bytes
 
             lda file_counter
-            and #$01
+            cmp dirlen
             zif_eq
                 jsr newline
+                lda #0 
+                sta file_counter
             zendif
         zendif
 
@@ -998,6 +1004,39 @@ zproc printi
     rts
 zendproc
 
+; Sets number of files to print per line
+; Defaults to 2 if no screen driver is available
+zproc set_dirlen
+    ; Find screen driver
+    lda #<DRVID_SCREEN
+    ldx #>DRVID_SCREEN
+    ldy #BIOS_FINDDRV 
+    jsr BIOS    
+
+    ; Defailt to 2 files per line if no driver is found
+    zif_cs
+        lda #2
+        sta dirlen
+        rts
+    zendif
+    
+    ; Get screen width and calculate number of files per line
+    sta SCREEN+1
+    stx SCREEN+2
+
+    ldy #SCREEN_GETSIZE
+    jsr SCREEN
+    tax
+    inx
+    txa 
+    lsr
+    lsr
+    lsr
+    lsr
+    sta dirlen
+    rts 
+zendproc
+
 space:
     lda #' '
     jmp bdos_CONOUT
@@ -1009,6 +1048,9 @@ newline:
     jmp bdos_CONOUT
 
     .data
+
+SCREEN:
+    jmp 0
 
 ; Submit file FCB.
 submit_fcb:
@@ -1024,6 +1066,7 @@ NOINIT
 
 stackptr: .fill 1           ; stack pointer on startup
 drive:    .fill 1           ; current drive, 0-based
+dirlen:   .fill 1           ; number of files to list per line
 cmdline:  .fill 128         ; command line buffer
 cmdfcb:   .fill XFCB__SIZE  ; FCB of command
 userfcb:  .fill XFCB__SIZE  ; parameter FCB


### PR DESCRIPTION
The screen driver is used by CCP to find how many filenames can be printed per line, so that the screen real estate is used more efficiently on systems with more than 40 columns. If no screen driver is found it defaults to 2 files per line as before.

In order to support loading drivers with a different number of columns (e.g. tty80drv on the Atari 800) the screen driver is checked every time the dir command is run.

See the screenshots below for the results with 40 columns, 80 columns, 64 columns and with no screen driver:

Atari 800 40 columns:
![atari800_40col](https://github.com/davidgiven/cpm65/assets/106430829/3cc40858-e7f1-44b0-93a1-014ec57ff01a)

Atari 800 80 columns:
![atari800_80col](https://github.com/davidgiven/cpm65/assets/106430829/8b7aeef0-5794-430a-a61e-1ae05a357e61)

BBC Micro 40 columns:
![bbcmicro_40col](https://github.com/davidgiven/cpm65/assets/106430829/3452f607-9910-4a43-91aa-77d1412cf6ef)

BBC Micro 80 columns:
![bbcmicro_80col](https://github.com/davidgiven/cpm65/assets/106430829/d14a68f8-0e9b-4930-b4cc-48b216776b42)

My homebrew computer with 64 columns:
![daimx_64col](https://github.com/davidgiven/cpm65/assets/106430829/79b47184-d5c3-4297-9994-f8adcfd3c95b)

C64 with no screen driver:
![C64_no_screendriver](https://github.com/davidgiven/cpm65/assets/106430829/7282c7aa-0ed0-43e1-91ee-61b86f82db1f)
