### PR TITLE
Set active_drive in BDOS when changing drive

### DIFF
--- a/src/bdos/filesystem.S
+++ b/src/bdos/filesystem.S
@@ -1338,12 +1338,9 @@ zendproc
 
 zproc bdos_LOGINDRIVE
     lda param+0
+    sta current_drive       ; Set the current drive variable
 zendproc
 zproc internal_LOGINDRIVE
-    ; Set the current drive
-
-    sta current_drive
-
     ; Select the drive.
 
     jsr select_active_drive

--- a/src/bdos/filesystem.S
+++ b/src/bdos/filesystem.S
@@ -1340,6 +1340,10 @@ zproc bdos_LOGINDRIVE
     lda param+0
 zendproc
 zproc internal_LOGINDRIVE
+    ; Set the current drive
+
+    sta current_drive
+
     ; Select the drive.
 
     jsr select_active_drive

--- a/src/ccp.S
+++ b/src/ccp.S
@@ -294,8 +294,6 @@ zproc entry_DIR
     ; Set the drive.
 
     ldx userfcb+FCB_DR
-
-
     dex
     zif_mi
         ldx drive
@@ -773,7 +771,7 @@ calltemp:
 read_command_sector:
     lda temp+0
     ldx temp+1
-    jsr bdos_SETDMAIs this the expected behavior, i.e. is it up to the application to reset the active drive before exiting? Or should CCP reset the active drive when the transient program exits?
+    jsr bdos_SETDMA
     lda #<cmdfcb
     ldx #>cmdfcb
     jsr bdos_READSEQUENTIAL

--- a/src/ccp.S
+++ b/src/ccp.S
@@ -294,8 +294,6 @@ zproc entry_DIR
     ; Set the drive.
 
     ldx userfcb+FCB_DR
-
-
     dex
     zif_mi
         ldx drive
@@ -763,8 +761,8 @@ zproc entry_TRANSIENT
 
     ; Reload disk.
 
-    lda drive
-    jsr bdos_SELECTDISK
+    jsr bdos_GETDRIVE
+    sta drive
     rts
 
 calltemp:
@@ -773,7 +771,7 @@ calltemp:
 read_command_sector:
     lda temp+0
     ldx temp+1
-    jsr bdos_SETDMAIs this the expected behavior, i.e. is it up to the application to reset the active drive before exiting? Or should CCP reset the active drive when the transient program exits?
+    jsr bdos_SETDMA
     lda #<cmdfcb
     ldx #>cmdfcb
     jsr bdos_READSEQUENTIAL

--- a/src/ccp.S
+++ b/src/ccp.S
@@ -294,6 +294,8 @@ zproc entry_DIR
     ; Set the drive.
 
     ldx userfcb+FCB_DR
+
+
     dex
     zif_mi
         ldx drive
@@ -771,7 +773,7 @@ calltemp:
 read_command_sector:
     lda temp+0
     ldx temp+1
-    jsr bdos_SETDMA
+    jsr bdos_SETDMAIs this the expected behavior, i.e. is it up to the application to reset the active drive before exiting? Or should CCP reset the active drive when the transient program exits?
     lda #<cmdfcb
     ldx #>cmdfcb
     jsr bdos_READSEQUENTIAL

--- a/src/ccp.S
+++ b/src/ccp.S
@@ -294,6 +294,8 @@ zproc entry_DIR
     ; Set the drive.
 
     ldx userfcb+FCB_DR
+
+
     dex
     zif_mi
         ldx drive
@@ -761,8 +763,8 @@ zproc entry_TRANSIENT
 
     ; Reload disk.
 
-    jsr bdos_GETDRIVE
-    sta drive
+    lda drive
+    jsr bdos_SELECTDISK
     rts
 
 calltemp:
@@ -771,7 +773,7 @@ calltemp:
 read_command_sector:
     lda temp+0
     ldx temp+1
-    jsr bdos_SETDMA
+    jsr bdos_SETDMAIs this the expected behavior, i.e. is it up to the application to reset the active drive before exiting? Or should CCP reset the active drive when the transient program exits?
     lda #<cmdfcb
     ldx #>cmdfcb
     jsr bdos_READSEQUENTIAL


### PR DESCRIPTION
Small fix to set the active_drive variable in BDOS when changing drives, so that bdos_GETDRIVE returns the correct drive number.

A small fix in the CCP to reselect the drive after running a transient program is also included.

Fixes several issues mentioned in #113 