### PR TITLE
Fix comments regarding Atari disks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ pet8096.d64
 x16.zip
 oric.dsk
 __pycache__
+neo6502.zip
+sorbus.zip

--- a/diskdefs
+++ b/diskdefs
@@ -53,7 +53,6 @@ diskdef generic-1m
 end
 
 # Simple SSSD disk on the Atari 810 or 1050 diskdrive
-# Reserve three tracks for BIOS+BDOS
 diskdef atari90
     seclen 128
     tracks 40
@@ -65,8 +64,8 @@ diskdef atari90
 end
 
 # Large ATR for use with emulators, hardware drive emulators or mounting
-# with AVG/SIDE cartridges on real hardware. seclen stil 128 so it uses
-# the same BIOS code as before. 8190 sectors. Almost 1MB.
+# with AVG/SIDE cartridges on real hardware. seclen is still 128. It uses
+# the same BIOS code as atari90. 8190 sectors. Almost 1MB.
 diskdef atarihd
     seclen 128
     tracks 455

--- a/src/arch/atari800/build.py
+++ b/src/arch/atari800/build.py
@@ -33,7 +33,7 @@ mkcpmfs(
         "1:olivetti.fnt": "third_party/fonts/atari/olivetti.fnt",
     }
     | MINIMAL_APPS
-    | BIG_APPS,
+    | SCREEN_APPS
 )
 
 normalrule(


### PR DESCRIPTION
Fix out of date comment. Used to be three boot tracks, but since the loader was introduced, it's only one.

Regards,
Ivo
