### PR TITLE
Nano6502 USB keyboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ the same time.
 
   - The text output is over HDMI, with 640x480 video output and a 80x30 console. It has a SCREEN driver.
 
-  - The input is currently using the built in USB serial port. This way, this port can be run with only the Tang Nano 20K board without any specific carrier board.
+  - The text input can be done using either the built in USB serial port or a USB keyboard with the [nanoComp](https://github.com/venomix666/nanoComp) carrier board. This way, this port can be run with only the Tang Nano 20K board, or with the carrier board for stand-alone use.
 
   - To use, write the `nano6502.img` file into the SD-card using `dd` or your preferred SD-card image writer. If you are updating the image and want to preserve the data on all drives except `A`, write the `nano6502_sysonly.img` instead.
 

--- a/src/arch/nano6502/nano6502.S
+++ b/src/arch/nano6502/nano6502.S
@@ -12,6 +12,7 @@ IO_page_led = $02
 IO_page_sdcard = $03
 IO_page_video = $04
 IO_page_timer = $05
+IO_page_keyb = $06
 IO_page_reg = $00
 ROM_sel_reg = $02
 
@@ -53,6 +54,8 @@ uart_tx_done = $fe01
 uart_rx_data = $fe02
 uart_rx_avail = $fe03
 
+keyb_data_avail = $fe00
+keyb_data = $fe01
 
 ; Offset to second byte of SDCARD address
 BDOS_OFFSET = $1
@@ -270,18 +273,31 @@ zendproc
 ; C if no key is pending, !C if key pending
 zproc tty_const
     lda pending_key
-    zif_eq
-        lda #IO_page_uart
-        sta IO_page_reg
-        lda uart_rx_avail
-        zif_eq
-            lda #$00
-            sec
-            rts
-        zendif
-        lda uart_rx_data
-        sta pending_key
-    zendif
+    bne tty_const_done
+    
+    lda #IO_page_uart
+    sta IO_page_reg
+    lda uart_rx_avail
+    beq tty_const_keyb
+    lda uart_rx_data
+    sta pending_key
+    jmp tty_const_done
+       
+tty_const_keyb:
+    lda #IO_page_keyb
+    sta IO_page_reg
+    lda keyb_data_avail
+    beq tty_const_nokey
+    lda keyb_data
+    sta pending_key
+    jmp tty_const_done
+ 
+tty_const_nokey:            
+    lda #$00
+    sec
+    rts
+    
+tty_const_done:
     lda #$ff
     clc
     rts
@@ -292,12 +308,21 @@ zendproc
 zproc tty_conin
     lda pending_key
     zif_eq
+tty_input_wait:
 	    lda #IO_page_uart
         sta IO_page_reg
-tty_input_wait:
         lda uart_rx_avail
+        beq tty_input_keyb
+        lda uart_rx_data
+        clc    
+        rts
+tty_input_keyb:
+        lda #IO_page_keyb
+        sta IO_page_reg
+        lda keyb_data_avail
         beq tty_input_wait
-        lda uart_rx_data    
+        lda keyb_data
+        clc
         rts
     zendif
 
@@ -442,13 +467,21 @@ screen_getchar_wait:
     sta IO_page_reg
     lda uart_rx_avail
     bne screen_getchar_data
+    lda #IO_page_keyb
+    sta IO_page_reg
+    lda keyb_data_avail
+    bne screen_getchar_data_keyb 
     lda #IO_page_timer
     sta IO_page_reg
     lda timer_idle
     beq screen_getchar_wait
     jmp nodata
+screen_getchar_data_keyb:
+    lda keyb_data
+    jmp screen_getchar_data_bsfix
 screen_getchar_data:
     lda uart_rx_data
+screen_getchar_data_bsfix:
     cmp #$08
     bne notbs
     lda #127
@@ -789,11 +822,11 @@ zproc bios_SETBANK
 zendproc
 
 zproc video_init
-    pha 
+    sta ptr1 
     lda #IO_page_video
     sta IO_page_reg    
     jsr video_wait
-    pla
+    lda ptr1
     rts
 zendproc
 


### PR DESCRIPTION
Added USB keyboard support to the nano6502 port for stand-alone use (with a carrier board). The USB UART input is still in place also so that the TangNano 20k-board can be used without a carrier board.