### PR TITLE
Fix ccp and bdos bug

### DIFF
--- a/src/bdos/conio.S
+++ b/src/bdos/conio.S
@@ -218,7 +218,7 @@ zproc bdos_READLINE
         cmp #18
         zif_eq
             jsr indent_new_line
-            ldy #1
+            ldy #2
             sty count
             zloop
                 ldy count

--- a/src/ccp.S
+++ b/src/ccp.S
@@ -11,7 +11,7 @@ ZEROPAGE
 cmdoffset:  .byte 0 ; current offset into command line (including size bytes)
 fcb:        .word 0 ; current FCB being worked on
 temp:       .word 0
-temp2:      .byte 0
+temp2:      .word 0
 
 zproc main
     tsx


### PR DESCRIPTION
While looking to fix multi drive support, I came across these two.

temp2 is used as a pointer, for example in printi. And entry_DIR uses temp+3, which is temp2+1.

CTRL-R in BDOS printed an extra random character in front of the repeated command line. I noticed that with a TTY driver that does not suppress characters < $20.
