### PR TITLE
Bdos fixes

### DIFF
--- a/src/bdos/filesystem.S
+++ b/src/bdos/filesystem.S
@@ -247,10 +247,8 @@ zproc convert_user_fcb
     lda current_user
     sta (param), y              ; update FCB
 
-    txa                         ; set the active drive
-    sta active_drive
-
-    jmp select_active_drive
+    txa                         ; select the active drive
+    jmp internal_LOGINDRIVE     ; and make sure it is logged in
 zendproc
 
 ; --- Close a file (flush the FCB to disk) ----------------------------------

--- a/src/bdos/filesystem.S
+++ b/src/bdos/filesystem.S
@@ -1314,6 +1314,9 @@ zproc internal_LOGINDRIVE
 
     sta active_drive
     jsr select_active_drive
+    zif_cs                  ; selecting drive failed, no need to go on
+        rts
+    zendif
 
     ; Decide if the drive was already logged in.
 
@@ -1323,7 +1326,8 @@ zproc internal_LOGINDRIVE
     jsr shiftr              ; flag at bottom of temp+0
 
     ror temp+0
-    zif_cs
+    zif_cs                  ; already logged in
+        clc                 ; drive exists and is successfully selected
         rts
     zendif
 
@@ -1414,6 +1418,7 @@ zproc internal_LOGINDRIVE
         zendif
     zendloop
 
+    clc
     rts
 zendproc
 


### PR DESCRIPTION
Eventually the change to convert_user_fcb is identical, but the problem was inside bdos_LOGINDRIVE. It would return C=1 if the drive was already logged in and hence convert_user_fcb would return with carry set in that case, which was wrong.

I separated both fixes in two commits. Ran a multitude of tests for about 15 minutes so I'm reasonably confident I didn't break anything this time.

As a bonus bdos_LOGINDRIVE has a proper return value in C now. There's no error handling during construction of the bitmap, but that could be added later and is outside the scope of this patch.
