### PR TITLE
bedit: make sure X is zero when calling BDOS CONIO

### DIFF
--- a/apps/bedit.asm
+++ b/apps/bedit.asm
@@ -470,6 +470,7 @@ command_tab:
 .zendproc
 
 .zproc putchar
+    ldx #0
     ldy #BDOS_CONIO
     jmp BDOS
 .zendproc


### PR DESCRIPTION
putchar calls CONIO, which takes a parameter in A and X, but X is never explicitly set. If X happens to be $ff or $fd, the character is not printed. This occurs for example with the 80 columns driver on the Atari.

Before:
![atari000](https://github.com/user-attachments/assets/b12a7f64-7d01-408e-9fa3-76fa02765d1e)

After:
![atari001](https://github.com/user-attachments/assets/bc9ca1f5-2c7a-44a3-8ad9-c72f20de805e)
