### PR TITLE
Atari multi drive support

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -36,6 +36,8 @@ jobs:
         path: |
           apple2e.po
           atari800.atr
+          atari800b.atr
+          atari800c.atr
           atari800hd.atr
           atari800xlhd.atr
           bbcmicro.ssd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,8 @@ jobs:
         assets: | 
           apple2e.po
           atari800.atr
+          atari800b.atr
+          atari800c.atr
           atari800hd.atr
           atari800xlhd.atr
           bbcmicro.ssd
@@ -71,6 +73,8 @@ jobs:
         files: |
           cpm65/apple2e.po
           cpm65/atari800.atr
+          cpm65/atari800b.atr
+          cpm65/atari800c.atr
           cpm65/atari800hd.atr
           cpm65/atari800xlhd.atr
           cpm65/bbcmicro.ssd

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .obj
 apple2e.po
 atari800.atr
+atari800b.atr
+atari800c.atr
+atari800d.atr
 atari800hd.atr
 atari800xlhd.atr
 bbcmicro.ssd

--- a/README.md
+++ b/README.md
@@ -251,6 +251,10 @@ the same time.
     ```tty80drv.com```. This will cost you 7kB of TPA for driver code,
     font data, and screen memory. It has a full SCREEN implementation, too.
 
+   - The single-sided single-density version supports up to four drives.
+     Extra applications and source code are spread accross the extra disks.
+     The 1MB images support two drives, but only one is used at the moment.
+
 ### Oric notes
 
   - This disk image is a MFM_DISK format disk as used by Oricutron. (If you need

--- a/build.py
+++ b/build.py
@@ -20,6 +20,7 @@ export(
         "oric.dsk": "src/arch/oric+diskimage",
         "apple2e.po": "src/arch/apple2e+diskimage",
         "atari800.atr": "src/arch/atari800+atari800_diskimage",
+        "atari800b.atr": "src/arch/atari800+atari800b_diskimage",
         "atari800hd.atr": "src/arch/atari800+atari800hd_diskimage",
         "atari800xlhd.atr": "src/arch/atari800+atari800xlhd_diskimage",
         "c64.d64": "src/arch/commodore+c64_diskimage",

--- a/build.py
+++ b/build.py
@@ -21,6 +21,7 @@ export(
         "apple2e.po": "src/arch/apple2e+diskimage",
         "atari800.atr": "src/arch/atari800+atari800_diskimage",
         "atari800b.atr": "src/arch/atari800+atari800b_diskimage",
+        "atari800c.atr": "src/arch/atari800+atari800c_diskimage",
         "atari800hd.atr": "src/arch/atari800+atari800hd_diskimage",
         "atari800xlhd.atr": "src/arch/atari800+atari800xlhd_diskimage",
         "c64.d64": "src/arch/commodore+c64_diskimage",

--- a/src/arch/atari800/atari800.S
+++ b/src/arch/atari800/atari800.S
@@ -53,12 +53,12 @@ _start:
     .byte 0
 
 #ifdef ATARI_XL
-    .byte 17            ; (filesize(atari800xlhd.exe)+127)/128
+    .byte 17            ; (filesize(+atari800xlhd_bios)+127)/128
 #else
 #   ifdef ATARI_HD
-        .byte 13        ; (filesize(atari800hd.exe)+127)/128
+        .byte 14        ; (filesize(+atari800hd_bios)+127)/128
 #   else
-        .byte 13        ; (filesize(atari800.exe)+127)/128
+        .byte 14        ; (filesize(+atari800_bios)+127)/128
 #   endif
 #endif
 
@@ -908,16 +908,22 @@ zendproc
 
 zproc bios_SELDSK
     cmp #0
-    zif_ne
-        sec                 ; invalid drive
+    zif_eq
+        sta drive_number
+        lda #<dph
+        ldx #>dph
+        clc
         rts
     zendif
-
-    sta drive_number
-
-    lda #<dph
-    ldx #>dph
-    clc
+    cmp #1
+    zif_eq
+        sta drive_number
+        lda #<dph_b
+        ldx #>dph_b
+        clc
+        rts
+    zendif
+    sec
     rts
 zendproc
 
@@ -1063,8 +1069,10 @@ mem_end:  .byte 0
 
 #ifdef ATARI_HD
 define_drive dph, 8190, 2048, 128, 18
+define_drive dph_b, 8190, 2048, 128, 18
 #else
 define_drive dph, 720, 1024, 64, 18
+define_drive dph_b, 720, 1024, 64, 18
 #endif
 
     .section .noinit, "ax", @nobits

--- a/src/arch/atari800/atari800.S
+++ b/src/arch/atari800/atari800.S
@@ -923,6 +923,24 @@ zproc bios_SELDSK
         clc
         rts
     zendif
+#ifndef ATARI_HD
+    cmp #2
+    zif_eq
+        sta drive_number
+        lda #<dph_c
+        ldx #>dph_c
+        clc
+        rts
+    zendif
+    cmp #3
+    zif_eq
+        sta drive_number
+        lda #<dph_d
+        ldx #>dph_d
+        clc
+        rts
+    zendif
+#endif
     sec
     rts
 zendproc
@@ -1061,7 +1079,7 @@ mem_base: .byte __USERTPA_START__@mos16hi
 mem_end:  .byte 0
 #endif
 
-; DPH for drive 0 (our only drive)
+; DPH for all drives
 
 ; number of sectors, blocksize, direntries, reserved _sectors_
 
@@ -1073,6 +1091,8 @@ define_drive dph_b, 8190, 2048, 128, 18
 #else
 define_drive dph, 720, 1024, 64, 18
 define_drive dph_b, 720, 1024, 64, 18
+define_drive dph_c, 720, 1024, 64, 18
+define_drive dph_d, 720, 1024, 64, 18
 #endif
 
     .section .noinit, "ax", @nobits

--- a/src/arch/atari800/build.py
+++ b/src/arch/atari800/build.py
@@ -47,6 +47,26 @@ normalrule(
     label="MAKEATR",
 )
 
+mkcpmfs(
+    name="atari800b_rawdiskimage",
+    format="atari90",
+    size=128 * 720,
+    items={
+    }
+    | BIG_APPS
+)
+
+normalrule(
+    name="atari800b_diskimage",
+    ins=[".+atari800b_rawdiskimage"],
+    outs=["atari800b.atr"],
+    commands=[
+        r"/usr/bin/printf '\x96\x02\x80\x16\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' > {outs[0]}",
+        "cat {ins[0]} >> {outs[0]}",
+    ],
+    label="MAKEATR",
+)
+
 llvmrawprogram(
     name="atari800hd_bios",
     srcs=["./atari800.S"],

--- a/src/arch/atari800/build.py
+++ b/src/arch/atari800/build.py
@@ -54,12 +54,35 @@ mkcpmfs(
     items={
     }
     | BIG_APPS
+    | PASCAL_APPS
 )
 
 normalrule(
     name="atari800b_diskimage",
     ins=[".+atari800b_rawdiskimage"],
     outs=["atari800b.atr"],
+    commands=[
+        r"/usr/bin/printf '\x96\x02\x80\x16\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' > {outs[0]}",
+        "cat {ins[0]} >> {outs[0]}",
+    ],
+    label="MAKEATR",
+)
+
+mkcpmfs(
+    name="atari800c_rawdiskimage",
+    format="atari90",
+    size=128 * 720,
+    items={
+    }
+    | MINIMAL_APPS_SRCS
+    | SCREEN_APPS_SRCS
+    | BIG_APPS_SRCS
+)
+
+normalrule(
+    name="atari800c_diskimage",
+    ins=[".+atari800c_rawdiskimage"],
+    outs=["atari800c.atr"],
     commands=[
         r"/usr/bin/printf '\x96\x02\x80\x16\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00' > {outs[0]}",
         "cat {ins[0]} >> {outs[0]}",


### PR DESCRIPTION
It currently generates three disk images for the SSSD setup, with minimal and screen apps at the boot disk like before, big and Pascal apps at the second disk, and source code on the third disk.

The 1MB images support two drives, even though the second is not used yet. But we'll need that anyway once the 8080 emulator uses a second drive to boot from.
