### PR TITLE
Move scrntest to SCREEN_APPS

### DIFF
--- a/config.py
+++ b/config.py
@@ -34,7 +34,6 @@ BIG_APPS = {
     "0:atbasic.com": "third_party/altirrabasic",
     "0:atbasic.txt": "cpmfs+atbasic_txt_cpm",
     "0:objdump.com": "apps+objdump",
-    "0:scrntest.com": "apps+scrntest",
     "0:kbdtest.com": "apps+kbdtest",
     "0:ansiterm.com": "apps+ansiterm",
 }
@@ -47,6 +46,7 @@ SCREEN_APPS = {
     "0:cls.com": "apps+cls",
     "0:life.com": "apps+life",
     "0:qe.com": "apps+qe",
+    "0:scrntest.com": "apps+scrntest",
     "0:vt52drv.com": "apps+vt52drv",
     "0:vt52test.com": "apps+vt52test",
 }


### PR DESCRIPTION
I noticed this one was installed on systems without a screen driver.