### PR TITLE
Added a SERIAL driver for the Nano6502

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ the same time.
   - To use, write the `nano6502.img` file into the SD-card using `dd` or your preferred SD-card image writer. If you are updating the image and want to preserve the data on all drives except `A`, write the `nano6502_sysonly.img` instead.
 
   - User area 1 on drive `A` contains utilities for setting the text and background colors, and a demo application which blinks the onboard LEDs.
+  - A SERIAL driver is available for the second UART, connected to pin 25 (RX) and 26 (TX) of the FPGA (and the UART header on the nanoComp carrier board). The baudrate is currently fixed to 115200.
 
 ### KIM-1 with K-1013 FDC notes
 

--- a/src/arch/nano6502/nano6502.S
+++ b/src/arch/nano6502/nano6502.S
@@ -355,7 +355,7 @@ zendproc
 defdriver SCREEN, DRVID_SCREEN, drvstrat_SCREEN, drv_SERIAL
 
 ; SCREEN driver strategy routine
-; Y = TTY opcode
+; Y = SCREEN opcode
 
 zproc drvstrat_SCREEN
     jmpdispatch screen_jmptable_lo, screen_jmptable_hi
@@ -553,8 +553,11 @@ normal_style:
     rts
 zendproc
 
+
+; --- SERIAL driver -------------------------------------------------------
+
 ; SERIAL driver strategy routine
-; Y = TTY opcode
+; Y = SERIAL opcode
 
 defdriver "SERIAL", DRVID_SERIAL, drvstrat_SERIAL, 0
 
@@ -576,8 +579,6 @@ serial_jmptable_hi:
     jmptabhi serial_outp
     jmptabhi serial_in 
 zendproc 
-
-; SERIAL driver
 
 zproc serial_inp
     lda #IO_page_uart

--- a/src/arch/nano6502/nano6502.S
+++ b/src/arch/nano6502/nano6502.S
@@ -54,6 +54,11 @@ uart_tx_done = $fe01
 uart_rx_data = $fe02
 uart_rx_avail = $fe03
 
+uart_b_tx_data = $fe04
+uart_b_tx_done = $fe05
+uart_b_rx_data = $fe06
+uart_b_rx_avail = $fe07
+
 keyb_data_avail = $fe00
 keyb_data = $fe01
 
@@ -309,7 +314,7 @@ zproc tty_conin
     lda pending_key
     zif_eq
 tty_input_wait:
-	    lda #IO_page_uart
+	lda #IO_page_uart
         sta IO_page_reg
         lda uart_rx_avail
         beq tty_input_keyb
@@ -347,7 +352,7 @@ zendproc
 
 ; --- SCREEN driver -------------------------------------------------------
 
-defdriver SCREEN, DRVID_SCREEN, drvstrat_SCREEN, 0
+defdriver SCREEN, DRVID_SCREEN, drvstrat_SCREEN, drv_SERIAL
 
 ; SCREEN driver strategy routine
 ; Y = TTY opcode
@@ -546,6 +551,91 @@ normal_style:
     lda #$00
     sta vid_style
     rts
+zendproc
+
+; SERIAL driver strategy routine
+; Y = TTY opcode
+
+defdriver "SERIAL", DRVID_SERIAL, drvstrat_SERIAL, 0
+
+zproc drvstrat_SERIAL
+    jmpdispatch serial_jmptable_lo, serial_jmptable_hi
+
+serial_jmptable_lo:
+    jmptablo serial_inp
+    jmptablo serial_out
+    jmptablo serial_open
+    jmptablo serial_close
+    jmptablo serial_outp
+    jmptablo serial_in    
+serial_jmptable_hi:
+    jmptabhi serial_inp
+    jmptabhi serial_out
+    jmptabhi serial_open
+    jmptabhi serial_close
+    jmptabhi serial_outp
+    jmptabhi serial_in 
+zendproc 
+
+; SERIAL driver
+
+zproc serial_inp
+    lda #IO_page_uart
+    sta IO_page_reg
+    lda uart_b_rx_avail
+    zif_eq
+    	; No data available
+        sec
+	    rts
+    zendif
+    lda uart_b_rx_data
+    clc
+    rts
+zendproc
+
+zproc serial_out
+    tax
+    lda #IO_page_uart
+    sta IO_page_reg
+wait_serial_out:
+    lda uart_b_tx_done
+    beq wait_serial_out
+    
+    txa
+    sta uart_b_tx_data
+    rts    
+zendproc
+
+serial_open:
+serial_close:
+rts
+
+zproc serial_outp
+    tax
+    lda #IO_page_uart
+    sta IO_page_reg
+
+    lda uart_b_tx_done
+    zif_eq
+        sec
+        rts
+    zendif 
+    txa
+    sta uart_b_tx_data
+    clc
+    rts   
+zendproc
+
+zproc serial_in
+    lda #IO_page_uart
+    sta IO_page_reg
+
+wait_serial_in:
+    lda uart_b_rx_avail
+    beq wait_serial_in
+
+    lda uart_b_rx_data
+    rts 
 zendproc
 
 ; -- Rest of the BIOS ---

--- a/src/arch/nano6502/nano6502.S
+++ b/src/arch/nano6502/nano6502.S
@@ -594,14 +594,14 @@ zproc serial_inp
 zendproc
 
 zproc serial_out
-    tax
+    sta ptr
     lda #IO_page_uart
     sta IO_page_reg
 wait_serial_out:
     lda uart_b_tx_done
     beq wait_serial_out
     
-    txa
+    lda ptr
     sta uart_b_tx_data
     rts    
 zendproc
@@ -611,7 +611,7 @@ serial_close:
 rts
 
 zproc serial_outp
-    tax
+    sta ptr
     lda #IO_page_uart
     sta IO_page_reg
 
@@ -620,7 +620,7 @@ zproc serial_outp
         sec
         rts
     zendif 
-    txa
+    lda ptr
     sta uart_b_tx_data
     clc
     rts   


### PR DESCRIPTION
Added a SERIAL driver for the Nano6502, connected to the second UART. I have tested it with ansiterm, xsend and xrecv and it seems to work fine.