### PR TITLE
Updates to  nano6502 serial driver. Added baudrate selection utility

### DIFF
--- a/src/arch/nano6502/build.py
+++ b/src/arch/nano6502/build.py
@@ -25,6 +25,7 @@ mkcpmfs(
         "1:colorfg.com": "src/arch/nano6502/utils+colorfg",
         "1:colorbg.com": "src/arch/nano6502/utils+colorbg",
         "1:ledtest.com": "src/arch/nano6502/utils+ledtest",
+	"1:baudrate.com": "src/arch/nano6502/utils+baudrate",
     }
     | MINIMAL_APPS
     | MINIMAL_APPS_SRCS

--- a/src/arch/nano6502/nano6502.S
+++ b/src/arch/nano6502/nano6502.S
@@ -614,7 +614,11 @@ zendproc
 
 serial_open:
 serial_close:
-rts
+    ; Perform a read to clear the buffer
+    lda #IO_page_uart
+    sta IO_page_reg
+    lda uart_b_rx_data
+    rts
 
 zproc serial_outp
     sta ptr
@@ -646,7 +650,7 @@ zendproc
 
 zproc serial_delay
     sta ptr
-    lda #$ff
+    lda #$20
     sta ptr1
     zrepeat
         dec ptr1

--- a/src/arch/nano6502/nano6502.S
+++ b/src/arch/nano6502/nano6502.S
@@ -344,6 +344,7 @@ zproc tty_conout
 	zendif
     jsr video_init
     sta tty_write 
+
     clc
     rts
 zendproc
@@ -586,6 +587,10 @@ zproc serial_inp
     lda uart_b_rx_avail
     zif_eq
     	; No data available
+
+        ; Short delay to prevent premature timeout in applications
+        jsr serial_delay
+
         sec
 	    rts
     zendif
@@ -637,6 +642,17 @@ wait_serial_in:
 
     lda uart_b_rx_data
     rts 
+zendproc
+
+zproc serial_delay
+    sta ptr
+    lda #$ff
+    sta ptr1
+    zrepeat
+        dec ptr1
+    zuntil_eq    
+    lda ptr
+    rts
 zendproc
 
 ; -- Rest of the BIOS ---

--- a/src/arch/nano6502/nano6502.ld
+++ b/src/arch/nano6502/nano6502.ld
@@ -1,6 +1,6 @@
 MEMORY {
     zp : ORIGIN = 0x10, LENGTH = 0xf0
-    ram (rw) : ORIGIN = 0x0300, LENGTH = 0x0E00
+    ram (rw) : ORIGIN = 0x0300, LENGTH = 0x0F00
 }
 
 SECTIONS {

--- a/src/arch/nano6502/utils/baudrate.S
+++ b/src/arch/nano6502/utils/baudrate.S
@@ -1,0 +1,190 @@
+; ---------------------------------------------------------------------------
+;
+; nano6502 baudrate utility
+;
+; Copyright (C) 2024 Henrik Löfgren
+; This file is licensed under the terms of the 2-cluse BSD license. Please
+; see the COPYING file in the root project directory for the full test.
+;
+; ---------------------------------------------------------------------------
+
+#include "zif.inc"
+#include "cpm65.inc"
+
+; UART IO bank addresses
+IO_page_reg = $00
+IO_page_UART = $01
+uart_b_baudrate = $fe08
+
+zproc main
+    lda #<banner
+    ldx #>banner
+    ldy #BDOS_WRITE_STRING
+    jsr BDOS
+
+    jsr print_baudrate
+
+    lda #<query
+    ldx #>query
+    ldy #BDOS_WRITE_STRING
+    jsr BDOS
+
+get_selection:
+    ldy #BDOS_CONSOLE_INPUT
+    jsr BDOS
+    
+    cmp #$2F
+    zif_cs
+        cmp #$36
+        bcc ok_selection
+        
+        lda #<br_invalid
+        ldx #>br_invalid
+        ldy #BDOS_WRITE_STRING
+        jsr BDOS
+
+        lda #<crlf
+        ldx #>crlf
+        ldy #BDOS_WRITE_STRING
+        jsr BDOS
+    zendif
+    jmp get_selection
+ok_selection:
+    sec
+    sbc #$30
+    
+    ldx #IO_page_UART
+    stx IO_page_reg
+    
+    sta uart_b_baudrate
+
+    lda #<updated
+    ldx #>updated
+    ldy #BDOS_WRITE_STRING
+    jsr BDOS
+
+    jsr print_baudrate
+
+	rts
+zendproc
+
+zproc print_baudrate
+    lda #<current
+    ldx #>current
+    ldy #BDOS_WRITE_STRING
+    jsr BDOS
+
+    lda #IO_page_UART
+    sta IO_page_reg
+    
+    lda uart_b_baudrate
+    cmp #0
+    zif_eq
+        lda #<br_4800
+        ldx #>br_4800
+        jmp print_br
+    zendif
+    
+    cmp #1
+    zif_eq
+        lda #<br_9600
+        ldx #>br_9600
+        jmp print_br
+    zendif
+
+    cmp #2
+    zif_eq
+        lda #<br_19200
+        ldx #>br_19200
+        jmp print_br
+    zendif
+
+    cmp #3
+    zif_eq
+        lda #<br_38400
+        ldx #>br_38400
+        jmp print_br
+    zendif
+
+    cmp #4
+    zif_eq
+        lda #<br_57600
+        ldx #>br_57600
+        jmp print_br
+    zendif
+
+    cmp #5
+    zif_eq
+        lda #<br_115200
+        ldx #>br_115200
+        jmp print_br
+    zendif
+    
+    lda #<br_invalid
+    ldx #>br_invalid
+    
+print_br:
+    ldy #BDOS_WRITE_STRING
+    jsr BDOS
+
+    lda #<crlf
+    ldx #>crlf
+    ldy #BDOS_WRITE_STRING
+    jsr BDOS
+
+    rts
+zendproc
+
+    .data
+banner:
+    .ascii "nano6502 baudrate utility"
+    .byte 13,10
+    .ascii "-------------------------"
+    .byte 13,10,0
+
+current:
+    .ascii "Current UART B baudrate: "
+    .byte 0
+
+br_4800:
+    .ascii "4800"
+    .byte 0
+
+br_9600:
+    .ascii "9600"
+    .byte 0
+
+br_19200:
+    .ascii "19200"
+    .byte 0
+
+br_38400:
+    .ascii "38400"
+    .byte 0
+
+br_57600:
+    .ascii "57600"
+    .byte 0
+
+br_115200:
+    .ascii "115200"
+    .byte 0
+
+br_invalid:
+    .ascii "Invalid setting"
+    .byte 0
+
+crlf:
+    .byte 13, 10, 0
+
+query:
+    .byte 13, 10
+    .ascii "Select new baudrate: "
+    .byte 13, 10
+    .ascii "[0] 4800, [1] 9600, [2] 19200, [3] 38400, [4] 57600, [5] 115200"
+    .byte 13, 10, 0
+
+updated:
+    .byte 13, 10
+    .ascii "Baudrate setting updated."
+    .byte 13,10,0

--- a/src/arch/nano6502/utils/build.py
+++ b/src/arch/nano6502/utils/build.py
@@ -23,3 +23,11 @@ llvmprogram(
         "include",
     ],
 )
+
+llvmprogram(
+    name="baudrate",
+    srcs=["./baudrate.S"],
+    deps=[
+        "include",
+    ],
+)


### PR DESCRIPTION
I added a small delay to the non-blocking serial read to prevent xrecv/xsend from timing out too quickly. I also added a utility to set the baudrate to user area 1.

I agree with your comment on the last PR that we need to figure out a good way to handle more than one UART, and I think that we should also add some configuration options to the uart driver. At least the baud rate would be good to set when opening the port, but maybe also data bits, parity and stop bits even though 8N1 is more or less standard these days.