### PR TITLE
zmalloc: remove two more unnecessary pointer checks...

### DIFF
--- a/lib/zmalloc.c
+++ b/lib/zmalloc.c
@@ -82,7 +82,7 @@ void *zcalloc(size_t nmemb, size_t size) {
 }
 
 static void merge_with_next_free(struct block_info *p) {
-    if (p->next && p->next->free) {
+    if (p->next->free) {
         struct block_info *q = p->next;
         p->size += q->size + block_info_size;
         p->next = q->next;
@@ -98,7 +98,7 @@ void zfree(void *ptr) {
     struct block_info *p = ptr - block_info_size;
     p->free = 1;
 
-    if (p->prev && p->prev->free) {    // if free, merge with previous block
+    if (p->prev->free) {    // if free, merge with previous block
         struct block_info *q = p->prev;
         q->size += p->size + block_info_size;
         q->next = p->next;


### PR DESCRIPTION
Forgot to remove these two checks when I added the sentinels.
Resulting code is smaller and faster.
