### PR TITLE
Moved serial apps to separate categories

### DIFF
--- a/config.py
+++ b/config.py
@@ -14,8 +14,6 @@ MINIMAL_APPS = {
     "0:ls.com": "apps+ls",
     "0:stat.com": "apps+stat",
     "0:submit.com": "apps+submit",
-    "0:xrecv.com": "apps+xrecv",
-    "0:xsend.com": "apps+xsend",
 }
 
 # Programs which only work on a real CP/M filesystem (not emulation).
@@ -34,8 +32,6 @@ BIG_APPS = {
     "0:atbasic.com": "third_party/altirrabasic",
     "0:atbasic.txt": "cpmfs+atbasic_txt_cpm",
     "0:objdump.com": "apps+objdump",
-    "0:kbdtest.com": "apps+kbdtest",
-    "0:ansiterm.com": "apps+ansiterm",
 }
 
 BIG_APPS_SRCS = {}
@@ -49,6 +45,7 @@ SCREEN_APPS = {
     "0:scrntest.com": "apps+scrntest",
     "0:vt52drv.com": "apps+vt52drv",
     "0:vt52test.com": "apps+vt52test",
+    "0:kbdtest.com": "apps+kbdtest",
 }
 
 BIG_SCREEN_APPS = {
@@ -63,4 +60,13 @@ PASCAL_APPS = {
     "0:pasc.obb": "third_party/pascal-m+pasc-obb",
     "0:pload.com": "third_party/pascal-m+loader",
     "0:hello.pas": "cpmfs+hello_pas_cpm",
+}
+
+SERIAL_APPS = {
+    "0:xrecv.com": "apps+xrecv",
+    "0:xsend.com": "apps+xsend",
+}
+
+SERIAL_SCREEN_APPS = {
+    "0:ansiterm.com": "apps+ansiterm",
 }

--- a/src/arch/bbcmicro/build.py
+++ b/src/arch/bbcmicro/build.py
@@ -7,7 +7,6 @@ from config import (
     BIG_APPS_SRCS,
     SCREEN_APPS,
     SCREEN_APPS_SRCS,
-    BIG_SCREEN_APPS,
     PASCAL_APPS,
 )
 
@@ -28,7 +27,6 @@ mkcpmfs(
     | BIG_APPS_SRCS
     | SCREEN_APPS
     | SCREEN_APPS_SRCS
-    | BIG_SCREEN_APPS
     | PASCAL_APPS
 )
 

--- a/src/arch/bbcmicro/build.py
+++ b/src/arch/bbcmicro/build.py
@@ -7,6 +7,7 @@ from config import (
     BIG_APPS_SRCS,
     SCREEN_APPS,
     SCREEN_APPS_SRCS,
+    BIG_SCREEN_APPS,
     PASCAL_APPS,
 )
 
@@ -27,7 +28,8 @@ mkcpmfs(
     | BIG_APPS_SRCS
     | SCREEN_APPS
     | SCREEN_APPS_SRCS
-    | PASCAL_APPS,
+    | BIG_SCREEN_APPS
+    | PASCAL_APPS
 )
 
 mkdfs(

--- a/src/arch/nano6502/build.py
+++ b/src/arch/nano6502/build.py
@@ -9,6 +9,8 @@ from config import (
     SCREEN_APPS,
     BIG_SCREEN_APPS,
     PASCAL_APPS,
+    SERIAL_APPS,
+    SERIAL_SCREEN_APPS,
 )
 
 llvmrawprogram(
@@ -34,7 +36,9 @@ mkcpmfs(
     | BIG_APPS_SRCS
     | SCREEN_APPS
     | BIG_SCREEN_APPS
-    | PASCAL_APPS,
+    | PASCAL_APPS
+    | SERIAL_APPS
+    | SERIAL_SCREEN_APPS
 )
 
 mkcpmfs(

--- a/src/arch/sorbus/build.py
+++ b/src/arch/sorbus/build.py
@@ -8,6 +8,7 @@ from config import (
     BIG_APPS,
     BIG_APPS_SRCS,
     PASCAL_APPS,
+    SERIAL_APPS,
 )
 
 llvmrawprogram(
@@ -25,7 +26,8 @@ mkcpmfs(
     | MINIMAL_APPS_SRCS
     | BIG_APPS
     | BIG_APPS_SRCS
-    | PASCAL_APPS,
+    | PASCAL_APPS
+    | SERIAL_APPS
 )
 
 zip(


### PR DESCRIPTION
As xsend and xrecv can only be used on targets with a SERIAL driver, I moved them to the category SERIAL_APPS which I added to the nano6502 and Sorbus build scripts.

Likewise, ansiterm requires both a SERIAL and a SCREEN driver, so I moved it to SERIAL_SCREEN_APPS. It is currently only the nano6502 which has both drivers.

I also moved kbdtest to SCREEN_APPS as it requires the SCREEN driver.

With these changes, I could also add Dwarfstar to the BBC Micro disk (with just about no margin at all).