### PR TITLE
Filtering of arrow keys in TTY-driver

### DIFF
--- a/src/arch/commodore/pet.S
+++ b/src/arch/commodore/pet.S
@@ -582,6 +582,11 @@ zproc tty_conin
         lda #0xff
         ldx #0xff
         jsr screen_getchar
+        ; Filter out arrow keys
+        cmp #$80
+        zif_cs
+            lda #0
+        zendif
     zuntil_cc
 
     rts

--- a/src/arch/nano6502/nano6502.S
+++ b/src/arch/nano6502/nano6502.S
@@ -313,7 +313,7 @@ zproc tty_conin
     lda pending_key
     zif_eq
 tty_input_wait:
-	lda #IO_page_uart
+	    lda #IO_page_uart
         sta IO_page_reg
         lda uart_rx_avail
         beq tty_input_keyb
@@ -326,6 +326,11 @@ tty_input_keyb:
         lda keyb_data_avail
         beq tty_input_wait
         lda keyb_data
+        ; Filter out arrow keys
+        cmp #$80
+        zif_cs
+            lda #0
+        zendif
         clc
         rts
     zendif

--- a/src/arch/oric/oric.S
+++ b/src/arch/oric/oric.S
@@ -689,6 +689,7 @@ zproc tty_const
     zendif
 
     lda pending_key
+   
     zif_ne
         lda #0xff
     zendif
@@ -704,6 +705,11 @@ zproc tty_conin
         lda #0xff
         ldx #0xff
         jsr screen_getchar
+        ; Filter out arrow keys
+        cmp #$80
+        zif_cs
+            lda #0
+        zendif
     zuntil_cc
 
     rts


### PR DESCRIPTION
This PR adds filtering of the arrow keys in the TTY drivers of the Oric, PET and nano6502. The Atari does not need the filtering as the translation is done in the SCREEN driver.

I tried to also add filtering to the BBC Micro, but there is seems like the MOS moves the cursor when pressing the arrow keys and I didn't find a simple way to prevent that.