### PR TITLE
Two drives support for the Apple II

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -35,6 +35,7 @@ jobs:
         name: ${{ github.event.repository.name }}.${{ github.sha }}
         path: |
           apple2e.po
+          apple2e_b.po
           atari800.atr
           atari800b.atr
           atari800c.atr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,7 @@ jobs:
         tag: dev
         assets: | 
           apple2e.po
+          apple2e_b.po
           atari800.atr
           atari800b.atr
           atari800c.atr

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .*.swp
 .obj
 apple2e.po
+apple2e_b.po
 atari800.atr
 atari800b.atr
 atari800c.atr

--- a/README.md
+++ b/README.md
@@ -221,9 +221,10 @@ the same time.
   - To use, place the contents of the `appleiie.po` file onto a disk and boot
     it. The disk image has been munged according to ProDOS sector ordering.
 
-  - It supports a single drive on slot 6 drive 1. You need a 80-column card
-    (but not any aux memory). The console is a standard 80x24, and there is
-    a SCREEN driver.
+  - The contents of the `appleiie_b.po`can be placed on the second drive.
+
+  - It supports two drives on slot 6. You need a 80-column card (but not any
+  aux memory). The console is a standard 80x24, and there is a SCREEN driver.
 
   - This port runs completely bare-metal and does not use any ROM routines.
 

--- a/build.py
+++ b/build.py
@@ -19,6 +19,7 @@ export(
         "bbcmicro.ssd": "src/arch/bbcmicro+diskimage",
         "oric.dsk": "src/arch/oric+diskimage",
         "apple2e.po": "src/arch/apple2e+diskimage",
+        "apple2e_b.po": "src/arch/apple2e+diskimage_b",
         "atari800.atr": "src/arch/atari800+atari800_diskimage",
         "atari800b.atr": "src/arch/atari800+atari800b_diskimage",
         "atari800c.atr": "src/arch/atari800+atari800c_diskimage",

--- a/src/arch/apple2e/apple2e.S
+++ b/src/arch/apple2e/apple2e.S
@@ -154,13 +154,16 @@ _start:
         inx
     zuntil_mi
 
-    ; Initialise the disk.
+    ; Initialise the disks.
 
     ldx #0
     stx current_phase
+    stx current_phase_a     ; already at track 0 after boot
+    stx selected_drive
     stx buffer_dirty
     dex
     stx buffered_track
+    stx current_phase_b     ; unkown position of the head
 
     ; Read the BDOS.
 
@@ -748,17 +751,76 @@ zendproc
 ; Sets carry on error.
 
 zproc bios_SELDSK
-    cmp #0
-    zif_ne
+    cmp #2
+    zif_pl
         sec                 ; invalid drive
         rts
     zendif
 
-    lda #<dph
-    ldx #>dph
+    cmp selected_drive
+    zif_ne
+        jsr change_drive
+    zendif
+
+    lda selected_drive
+    cmp #0
+    zif_eq
+        ; Drive A:
+        lda #<dph
+        ldx #>dph
+        clc
+        rts
+    zendif
+
+    ; Drive B:
+    lda #<dph_b
+    ldx #>dph_b
     clc
     rts
 zendproc
+
+zproc change_drive
+    pha
+    lda buffer_dirty
+    zif_ne
+        jsr write_track
+    zendif
+    lda #$FF
+    sta buffered_track
+    pla
+
+    sta selected_drive
+    cmp #0
+    zif_eq
+        ; B: to A:
+        ldx #DISK_SLOT
+        lda DISK_DRIVE1, x
+
+        lda current_phase
+        sta current_phase_b
+        lda current_phase_a
+        sta current_phase
+        rts
+    zendif
+
+    ; A: to B:
+    ldx #DISK_SLOT
+    lda DISK_DRIVE2, x
+
+    lda current_phase
+    sta current_phase_a
+    lda current_phase_b
+    sta current_phase
+    zif_ne
+        ; The head position is unknown. Seek to track 0.
+        lda #80
+        sta current_phase
+        lda #0
+        jsr seek_to_track
+    zendif
+    rts
+zendproc
+
 
 ; Set the current absolute sector number.
 ; XA is a pointer to a three-byte sector number.
@@ -1349,9 +1411,9 @@ zp_end:     .byte __ZEROPAGE_END__
 mem_base:   .byte __TPA0_START__@mos16hi, __TPA1_START__@mos16hi
 mem_end:    .byte __TPA0_END__@mos16hi,   __TPA1_END__@mos16hi
 
-; DPH for drive 0 (our only drive)
-
+; DPH for drive 0 and 1
 define_drive dph, 0x42e, 1024, 64, 32
+define_drive dph_b, 0x42e, 1024, 64, 32
 
 .section aligneddata, "ax", @nobits
 disk_twos_buffer:   .fill 86 ; must be aligned
@@ -1364,6 +1426,9 @@ cursory:            .fill 1
 cursorf:            .fill 1 ; SCREEN flags
 current_bank:       .fill 1
 current_phase:      .fill 1
+current_phase_a:    .fill 1
+current_phase_b:    .fill 1
+selected_drive:     .fill 1
 directory_buffer:   .fill 128
 decode_tab:         .fill 0x100 - DECODE_TABLE_START
 wanted_track:       .fill 1

--- a/src/arch/apple2e/build.py
+++ b/src/arch/apple2e/build.py
@@ -6,6 +6,9 @@ from config import (
     BIG_APPS,
     BIG_APPS_SRCS,
     SCREEN_APPS,
+    SCREEN_APPS_SRCS,
+    BIG_SCREEN_APPS,
+    PASCAL_APPS,
 )
 
 llvmcfile(
@@ -62,6 +65,20 @@ mkcpmfs(
     | MINIMAL_APPS
     | MINIMAL_APPS_SRCS,
 )
+
+mkcpmfs(
+    name="diskimage_b",
+    format="appleiie",
+    bootimage=".+bios_shuffled",
+    size=143360,
+    items={
+    }
+    | SCREEN_APPS
+    | SCREEN_APPS_SRCS
+    | BIG_SCREEN_APPS
+    | PASCAL_APPS,
+)
+
 
 mametest(
     name="mametest",


### PR DESCRIPTION
Adds two drives on slot 6 for the Apple II. I just needed to update `bios_SELDSK`. I also added a second disk to the build.

Tested on the emulators Virtual ][, MAME and my own. I don't have a real machine setup for testing.

A drawback of this second drive support is that the system will be waiting forever on access to B: for a disk to be inserted. That was quite common on the Apple II, but running on an emulator with no disks sounds, the first experience for users testing cpm65 could be bad. That may be reason enough for not merging the change.

The wait happens on `read_header` searching for a sector prologue. I  dare not touch all that time sensitive code for the Disk II.