### PR TITLE
Mandelbrot

### DIFF
--- a/apps/build.py
+++ b/apps/build.py
@@ -51,6 +51,7 @@ for prog in [
     "attr",
     "copy",
     "life",
+    "mbrot",
     "mkfs",
     "objdump",
     "qe",

--- a/apps/mbrot.c
+++ b/apps/mbrot.c
@@ -1,0 +1,84 @@
+/*
+ * Mandelbrot for CP/M-65
+ *
+ * Adapted from https://github.com/Johnlon/mandelbrot/blob/main/integer.c
+ * by Henrik Löfgren 2024.
+ * 
+ */
+
+#include <stdio.h>
+#include <cpm.h>
+#include "lib/screen.h"
+
+int main()
+{	
+    int width, height;
+    int X1, X2, Y1, Y2, LIMIT;
+    int px, py;
+    int x0, y0;
+    int x,y,i;
+    int xSqr, ySqr;
+    int sum;
+    int xt;
+
+    char * chr = ".,_-*!$&0 ";
+	
+    int maxIters = 10;
+
+    if(!screen_init()) {
+        cpm_printstring("Error: No SCREEN driver, exiting\r\n");
+        cpm_warmboot();
+    }
+    screen_getsize(&width, &height);
+
+    screen_clear();
+    screen_setcursor(0,0);
+
+    // 6 bit precision fixed point
+    X1 = 224;
+    X2 = 160;
+    Y1 = 128;
+    Y2 = 64;
+    LIMIT = 512;
+    px=0; 
+    py=0;
+    
+    while (py < height) {
+        while (px < width) {
+
+            x0 = ((px*X1) / width) - X2;
+            y0 = ((py*Y1) / height) - Y2;
+
+            x=0;
+            y=0;
+
+            i=0;
+
+            while (i < maxIters) {
+                xSqr = (x * x) >> 6;
+                ySqr = (y * y) >> 6;
+
+                sum =(xSqr + ySqr);
+                if (sum > LIMIT) { 
+                    break;
+                }
+
+                xt = xSqr - ySqr + x0;
+
+                y = (((x * y) >> 6) << 1) + y0;
+                x=xt;
+    
+                i = i + 1;
+            }
+            i = i - 1;
+            screen_putchar(chr[i]);
+            px = px + 1;
+        }
+
+        cpm_printstring("\r\n");
+        py = py + 1;
+        px = 0;
+    } 
+	
+	return 0;
+}

--- a/apps/mbrot.c
+++ b/apps/mbrot.c
@@ -21,9 +21,9 @@ int main()
     int sum;
     int xt;
 
-    char * chr = ".,_-*!$&0 ";
+    char * chr = ".,_-*\\/!$&IO ";
 	
-    int maxIters = 10;
+    int maxIters = 13;
 
     if(!screen_init()) {
         cpm_printstring("Error: No SCREEN driver, exiting\r\n");

--- a/config.py
+++ b/config.py
@@ -52,7 +52,7 @@ SCREEN_APPS = {
 
 BIG_SCREEN_APPS = {
     "0:ds.com": "third_party/dwarfstar",
-    "0:dsr.txt": "third_party/dwarfstar/+ds_txt_cpm",
+    "0:ds.txt": "third_party/dwarfstar/+ds_txt_cpm",
 }
 
 SCREEN_APPS_SRCS = {"0:cls.asm": "apps+cls_asm_cpm"}

--- a/config.py
+++ b/config.py
@@ -47,11 +47,12 @@ SCREEN_APPS = {
     "0:vt52drv.com": "apps+vt52drv",
     "0:vt52test.com": "apps+vt52test",
     "0:kbdtest.com": "apps+kbdtest",
+    "0:mbrot.com": "apps+mbrot",
 }
 
 BIG_SCREEN_APPS = {
     "0:ds.com": "third_party/dwarfstar",
-    "0:ds.txt": "third_party/dwarfstar/+ds_txt_cpm",
+    "0:dsr.txt": "third_party/dwarfstar/+ds_txt_cpm",
 }
 
 SCREEN_APPS_SRCS = {"0:cls.asm": "apps+cls_asm_cpm"}


### PR DESCRIPTION
I ported a small ASCII Mandelbrot generator, because why not? It uses the screen driver and adapts to the available screen size.

Here is how it looks on the PET as an example:

![pet_mbrot](https://github.com/user-attachments/assets/0ac880e2-42a3-4287-9b21-d5dfe30118da)