### PR TITLE
Fix some BDOS and CCP issues.

### DIFF
--- a/apps/ls.asm
+++ b/apps/ls.asm
@@ -36,35 +36,10 @@ endcondx=tmp+3
 .zp pfile, 2
 .zp pfile2, 2
 
+.label print_string
+
 start:
 .expand 1
-
-    ldy #BDOS_GET_CURRENT_DRIVE
-    jsr BDOS
-    sta tmp
-
-    lda cpm_fcb
-    beq keepcur
-
-    sta tmp
-    dec tmp        \ fcb.dr - 1
-
-keepcur:
-    lda tmp
-    ldy #BDOS_SELECT_DRIVE
-    jsr BDOS
-
-    ldy #BDOS_GET_CURRENT_DRIVE
-    jsr BDOS
-
-    cmp tmp
-    beq success
-
-    lda #<error
-    ldx #>error
-    jmp print_string    \ exits
-
-success:
     lda cpm_fcb+1
     cmp #' '
     bne no_fill_wildcards

--- a/src/bdos/filesystem.S
+++ b/src/bdos/filesystem.S
@@ -1604,14 +1604,20 @@ zproc allocate_unused_block
     sta temp+3
 
     zloop
+        ; Bounds check.
+
         lda temp+2
-        cmp blocks_on_disk+0 ; bounds check
-        bcs disk_full_error
-        sta temp+0
+        cmp blocks_on_disk+0
+        bcc not_out_of_bounds
 
         lda temp+3
-        cmp blocks_on_disk+1 ; bounds check
+        cmp blocks_on_disk+1
         bcs disk_full_error
+
+    not_out_of_bounds:
+        lda temp+2
+        sta temp+0
+        lda temp+3
         sta temp+1
 
         jsr get_bitmap_status

--- a/src/bdos/filesystem.S
+++ b/src/bdos/filesystem.S
@@ -55,6 +55,8 @@ zproc internal_ENDSYS
     pha
     tya
     pha
+    txa
+    pha
 
     lda old_fcb_drive
     zif_pl
@@ -62,6 +64,11 @@ zproc internal_ENDSYS
         sta (param), y      ; restore user FCB
     zendif
 
+    lda current_drive       ; reselect the current drive
+    jsr bios_SELDSK
+
+    pla
+    tax
     pla
     tay
     pla
@@ -1818,7 +1825,7 @@ NOINIT
 filesystem_state_start:
 find_first_count:       .byte 0
 active_drive:           .byte 0 ; drive currently being worked on
-old_drive:              .byte 0 ; if the drive has been overridden by the FCB
+old_active_drive:       .byte 0 ; if the drive has been overridden by the FCB
 old_fcb_drive:          .byte 0 ; drive in user FCB on entry
 write_protect_vector:   .word 0
 login_vector:           .word 0

--- a/src/bdos/filesystem.S
+++ b/src/bdos/filesystem.S
@@ -1605,9 +1605,15 @@ zproc allocate_unused_block
 
     zloop
         lda temp+2
+        cmp blocks_on_disk+0 ; bounds check
+        bcs disk_full_error
         sta temp+0
+
         lda temp+3
+        cmp blocks_on_disk+1 ; bounds check
+        bcs disk_full_error
         sta temp+1
+
         jsr get_bitmap_status
         and #$01
         zbreakif_eq
@@ -1628,6 +1634,15 @@ zproc allocate_unused_block
     lda temp+2
     ldx temp+3
     rts
+zendproc
+
+zproc disk_full_error
+    lda #<1f
+    ldx #>1f
+    jmp harderror
+1:
+    .ascii "BDOS: disk full"
+    .byte 13, 10, 0
 zendproc
 
 ; Sets a drive as being readonly.

--- a/src/bdos/filesystem.S
+++ b/src/bdos/filesystem.S
@@ -64,9 +64,6 @@ zproc internal_ENDSYS
         sta (param), y      ; restore user FCB
     zendif
 
-    lda current_drive       ; reselect the current drive
-    jsr bios_SELDSK
-
     pla
     tax
     pla
@@ -1846,7 +1843,6 @@ NOINIT
 filesystem_state_start:
 find_first_count:       .byte 0
 active_drive:           .byte 0 ; drive currently being worked on
-old_active_drive:       .byte 0 ; if the drive has been overridden by the FCB
 old_fcb_drive:          .byte 0 ; drive in user FCB on entry
 write_protect_vector:   .word 0
 login_vector:           .word 0

--- a/src/ccp.S
+++ b/src/ccp.S
@@ -386,17 +386,8 @@ zproc entry_DIR
         zuntil_mi
     zendif
 
-    ; Set the drive.
-
-    ldx userfcb+FCB_DR
-    dex
-    zif_mi
-        ldx drive
-    zendif
-    txa
-    jsr bdos_SELECTDISK
-
     ; Find number of files to print per line
+
     jsr set_dirlen
 
     ; Start iterating.


### PR DESCRIPTION
- Ensure that the CCP and ls don't change drive when listing a directory.

This avoids issues where the current drive according to the BDOS doesn't match the current drive according to the CCP, which can make odd things happen.

Fixes: #151
Fixes: #113

- Fail with a hard error when trying to write to a full disk.

Previously it would just keep searching up off the end of the bitmap and trying to write to out-of-bound blocks.

Fixes: #170
