### PR TITLE
nano6502: Fixed carry clear after sector write

### DIFF
--- a/src/arch/nano6502/nano6502.S
+++ b/src/arch/nano6502/nano6502.S
@@ -942,7 +942,7 @@ zproc bios_WRITE
     sta sd_write_strobe
 
     jsr sd_wait   
-    
+    clc 
     rts
 zendproc
 


### PR DESCRIPTION
The update to the BDOS triggered a bug which caused writing to the disk to fail, as the carry was not cleared before returning from bios_WRITE.

How this ever worked at all before is a mystery :)