### PR TITLE
Ohio Scientific Model 630 SCREEN driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ the same time.
 - The generated disk images can be used directly with [osiemu](https://github.com/ivop/osiemu), or converted to HFE format with its `osi2hfe` if you want to create real floppies or use it with a Gotek on real hardware.
 For use with one of the two WinOSI emulators [Mark's Lab](https://osi.marks-lab.com/software/tools.html) has a tool to convert HFE images to 65D format.
 - All systems boot with a plain TTY driver. If you have a 540B graphics card with the optional color option enabled, you can load a screen driver called `TTY540B` (located on drive D: on MF systems).
+For the Model 630 graphics card there's `TTY630`.
 On serial systems, you can load `SCRVT100` to enable the screen driver if you are connected with a VT100 terminal.
 
 ### Supported programs

--- a/src/arch/osi/build.py
+++ b/src/arch/osi/build.py
@@ -109,6 +109,7 @@ mkcpmfs(
     size=128 * 640,
     items={
         "0:tty540b.com": "src/arch/osi/utils+tty540b",
+        "0:tty630.com": "src/arch/osi/utils+tty630",
     }
     | SCREEN_APPS
     | SCREEN_APPS_SRCS
@@ -225,12 +226,16 @@ mkcpmfs(
     items={
         "0:ccp.sys@sr": "src+ccp",
         "0:bdos.sys@sr": "src/bdos",
+        "0:tty630.com": "src/arch/osi/utils+tty630",
     }
     | MINIMAL_APPS
     | BIG_APPS
     | PASCAL_APPS
     | MINIMAL_APPS_SRCS
     | BIG_APPS_SRCS
+    | SCREEN_APPS
+    | SCREEN_APPS_SRCS
+    | BIG_SCREEN_APPS
 )
 
 mkcpmfs(

--- a/src/arch/osi/utils/build.py
+++ b/src/arch/osi/utils/build.py
@@ -2,3 +2,4 @@ from build.llvm import llvmprogram
 
 llvmprogram( name="tty540b", srcs=["./tty540b.S"], deps=[ "include", ],)
 llvmprogram( name="scrvt100", srcs=["./scrvt100.S"], deps=[ "include", ],)
+llvmprogram( name="tty630", srcs=["./tty540b.S"], deps=[ "include", ], cflags=["-DOSI630"],)

--- a/src/arch/osi/utils/tty540b.S
+++ b/src/arch/osi/utils/tty540b.S
@@ -27,12 +27,35 @@ cury:       .fill 1
 
 drv_zp_end:
 
+#if OSI630
+
+SCREEN_WIDTH = 64
+SCREEN_HEIGHT = 16
+
+CONTROL = $d800
+
+ENABLE_64 = 0x01
+ENABLE_COLOR = 0x02
+
+NORMAL    = $00
+INVERSE   = $01
+CURSORXOR = (NORMAL ^ INVERSE)
+
+SCREENMEM   = $d000
+SECLASTLINE = $d380
+LASTLINE    = $d3c0
+
+COLORMEM    = $d400
+COLORXOR    = ((SCREENMEM ^ COLORMEM) / 256)
+
+#else
+
 SCREEN_WIDTH = 64
 SCREEN_HEIGHT = 32
 
 CONTROL = $de00
 
-ENABLE_64X32 = 0x01
+ENABLE_64 = 0x01
 ENABLE_COLOR = 0x04
 
 NORMAL    = $0e
@@ -45,6 +68,8 @@ LASTLINE    = $d7c0
 
 COLORMEM    = $e000
 COLORXOR    = ((SCREENMEM ^ COLORMEM) / 256)
+
+#endif
 
 ; -------------------------------------------------------------------------
 
@@ -60,7 +85,11 @@ drv_screen540b:
     .word DRVID_SCREEN
     .word drv_screen540b_strat
     .word 0
+#if OSI630
+    .ascii "SCREEN630"
+#else
     .ascii "SCREEN540B"
+#endif
     .byte 0
 
 zproc drv_screen540b_strat
@@ -105,7 +134,11 @@ drv_tty540b:
     .word DRVID_TTY
     .word drv_tty540b_strat
     .word 0
+#if OSI630
+    .ascii "TTY630"
+#else
     .ascii "TTY540B"
+#endif
     .byte 0
 
 zproc drv_tty540b_strat
@@ -173,7 +206,7 @@ zproc init
 
     jsr screen540b_clear
 
-    lda #(ENABLE_64X32 | ENABLE_COLOR)
+    lda #(ENABLE_64 | ENABLE_COLOR)
     sta CONTROL
 
     lda #<banner
@@ -207,19 +240,23 @@ clearscrn:
     sta SCREENMEM+1*256,y
     sta SCREENMEM+2*256,y
     sta SCREENMEM+3*256,y
+#ifndef OSI630
     sta SCREENMEM+4*256,y
     sta SCREENMEM+5*256,y
     sta SCREENMEM+6*256,y
     sta SCREENMEM+7*256,y
+#endif
     lda #NORMAL
     sta COLORMEM+0*256,y
     sta COLORMEM+1*256,y
     sta COLORMEM+2*256,y
     sta COLORMEM+3*256,y
+#ifndef OSI630
     sta COLORMEM+4*256,y
     sta COLORMEM+5*256,y
     sta COLORMEM+6*256,y
     sta COLORMEM+7*256,y
+#endif
     dey
     bne clearscrn
 
@@ -591,7 +628,11 @@ zendproc
     .data
 
 banner:
+#if OSI630
+    .ascii "tty630/screen630 driver loaded."
+#else
     .ascii "tty540b/screen540b driver loaded."
+#endif
     .byte 13, 10, 0
 
 ; -------------------------------------------------------------------------


### PR DESCRIPTION
See title.

Also, I sort of got a request for 5.25"/3.5" 80 tracks single density support. That's not a format that was originally supported by OSI back in the day, but apparently some people replaced their 5.25" 40 tracks drives with an 80-track one on their Superboard2/C1P/600 series machines in the eighties. YE-DOS supported that. Would you mind if I added yet-another OSI disk image with a proper DPH and updated img2osi? I could limit it to 600 systems only if you want. It's one new drive format as there is no difference between 5.25" and 3.5". Both are treated as 80 tracks, 300rpm, 125kbps (250kbps flux) single density.
