### PR TITLE
Fix attr command

### DIFF
--- a/apps/attr.c
+++ b/apps/attr.c
@@ -109,8 +109,6 @@ int main()
     while (r != 0xff)
     {
         DIRE* de = (DIRE*)cpm_default_dma + r;
-        if (de->rc == 0x80)
-            continue;
 
         if (modify)
         {
@@ -122,6 +120,10 @@ int main()
 
             de->us = dr; /* Convert to an FCB */
             cpm_set_file_attributes((FCB*)de);
+
+            /* cpm_set_file_attributes() resets directory index, so */
+            /* recover index for last file match */
+            cpm_findfirst((FCB*)de);
         }
 
         cpm_conout((de->f[8] & 0x80) ? 'R' : '-');


### PR DESCRIPTION
I've found a couple of issues with the `attr` command that prevent it from working properly:

```diff
@@ -109,8 +109,6 @@ int main()
     while (r != 0xff)
     {
         DIRE* de = (DIRE*)cpm_default_dma + r;
-        if (de->rc == 0x80)
-            continue;

         if (modify)
         {
```

I don't really know what the intent was here, but this prevented attr to work with files with size > 16K and also froze in an infinite loop as `r` was no longer updated.

```diff
@@ -122,6 +120,10 @@ int main()

             de->us = dr; /* Convert to an FCB */
             cpm_set_file_attributes((FCB*)de);
+
+            /* cpm_set_file_attributes() resets directory index, so */
+            /* recover index for last file match */
+            cpm_findfirst((FCB*)de);
         }

         cpm_conout((de->f[8] & 0x80) ? 'R' : '-');
```

`cpm_set_file_attributes()` calls `find_first`/`find_next`, so the directory index ends messed up. If you tried to modifiy the attributes of a file, for example, it looped endlessly re-modifying the same file. Executing a `find_first` with the last modified file restores the dir index.
