### PR TITLE
Harmless copy.c bug: Fail if no files match

### DIFF
--- a/apps/copy.c
+++ b/apps/copy.c
@@ -151,7 +151,7 @@ int main()
 			i = cpm_findnext(&wildcard_fcb);
 		}
 
-		if (stash == (FCB*)cpm_ram)
+		if (stash == (FCB*)top)
 			fatal("no files match");
 		buffer_size = ((uint16_t)stash - (uint16_t)cpm_ram) / 128;
 


### PR DESCRIPTION
This was making copy.com to end silently when using wildcards if no files matched. Pretty harmless, but a bug is a bug 😉 