### PR TITLE
Keep snes.img in the .obj tree

### DIFF
--- a/src/arch/snes/build.py
+++ b/src/arch/snes/build.py
@@ -68,7 +68,7 @@ tass64(
 simplerule(
     name="snes_cartridge",
     ins=[".+snes_cartridge_bin", "./checksum.py"],
-    outs=["snes.img"],
+    outs=["=snes.img"],
     commands=[
         "cp {ins[0]} {outs[0]}",
         "truncate -s %d {outs[0]}" % (2048 * 1024),


### PR DESCRIPTION
There is a small typo in the `build.py` file of the snes port and the `snes.img` file is being placed into the project root instead of into `./.obj/src/arch/snes/+snes_cartridge`