### PR TITLE
[KIM-1] Use X as index for OUTCH as Y is not preserved

### DIFF
--- a/src/arch/kim-1/boot/boot.S
+++ b/src/arch/kim-1/boot/boot.S
@@ -157,11 +157,11 @@ readdatr:
 
 e2: inc errorc          ; 02 READ ERROR CODE
 e1: inc errorc          ; 01 RECALIBRATE ERROR CODE
-    ldy #0
-1:  lda errmsg, y
+    ldx #0
+1:  lda errmsg, x
     beq 2f
     jsr OUTCH
-    iny
+    inx
     bne 1b
 2:  lda errorc
     jsr PRTBYT


### PR DESCRIPTION
The error messages for the kim-1 boot program were not displayed because I was using `Y` for the message index and it is not preserved when calling `OUTCH`.