### PR TITLE
Critical sys.com error and add sys.com to BIG_APPS

### DIFF
--- a/apps/sys.c
+++ b/apps/sys.c
@@ -16,8 +16,8 @@
 
 #define SYSTEM_FILES 2
 const char sys_files[SYSTEM_FILES][11] = {
-    "BDOS    SYS",
-    "CCP     SYS"
+    "CCP     SYS",
+    "BDOS    SYS"
 };
 
 DPH* dph;

--- a/config.py
+++ b/config.py
@@ -33,6 +33,7 @@ BIG_APPS = {
     "0:atbasic.txt": "cpmfs+atbasic_txt_cpm",
     "0:objdump.com": "apps+objdump",
     "0:mkfs.com": "apps+mkfs",
+    "0:sys.com": "apps+sys",
 }
 
 BIG_APPS_SRCS = {}


### PR DESCRIPTION
OK, this is embarrasing... While testing a new KIM-1 port I'm working on, I realised that the system files were copied in the wrong order, so the resulting disk was unbootable. I don't know when and how I reversed that, my apologies.