### PR TITLE
COPY: When using wildcards, remove attributes from the FCBs before creating the destination files

### DIFF
--- a/apps/copy.c
+++ b/apps/copy.c
@@ -160,6 +160,8 @@ int main()
 			src_fcb = *stash;
 			dest_fcb = *stash;
 			dest_fcb.dr = cpm_fcb2.dr;
+			for (uint8_t b=0; b < 11; b++)
+				dest_fcb.f[b] &= ~0x80;
 			stash++;
 
 			copy_file();


### PR DESCRIPTION
When using wildcards, if any of the source files is read-only, `COPY` fails when trying to write the first sector, as it creates the destination as read-only too. This happens because `COPY` uses the dirents as fcbs, so all the attributes of the source are preserved. In case of a copy without wildcards, the destination file is created without any attribute set.

I've opted for the simplest fix here:  remove all the attributes from the FCB before creating the destination file.