### PR TITLE
OSI: Fix RAM top detection. 

### DIFF
--- a/src/arch/osi/osi.S
+++ b/src/arch/osi/osi.S
@@ -163,10 +163,12 @@ init:
         lda ptr+1
         cmp #$c0
         zbreakif_eq
+        lda #$3f
         sta (ptr),y
         cmp (ptr),y
     zuntil_ne
 
+    lda ptr+1
     sec
     sbc #PAGES_PER_TRACK
     sta ptrkbuf                     ; put track buffer at ramtop


### PR DESCRIPTION
It has been tested on real hardware and the old code fails when there is less than 40kB of RAM. Real hardware returns the MSB of the address on the databus when there's no RAM at the specific location, which coincidentally was the same value I used during testing. This PR fixes that.

Regards,
Ivo
