### PR TITLE
Print the right drive in DIR listings

### DIFF
--- a/src/ccp.S
+++ b/src/ccp.S
@@ -437,7 +437,13 @@ zproc entry_DIR
             stx file_counter
             cmp #$00
             zif_eq
-                jsr bdos_GETDRIVE
+                ldy userfcb
+                zif_eq
+                    jsr bdos_GETDRIVE
+                zelse
+                    dey
+                    tya
+                zendif
                 clc
                 adc #'A'
                 jsr bdos_CONOUT

--- a/src/ccp.S
+++ b/src/ccp.S
@@ -438,11 +438,10 @@ zproc entry_DIR
             cmp #$00
             zif_eq
                 ldy userfcb
-                zif_eq
+                dey
+                tya
+                zif_mi
                     jsr bdos_GETDRIVE
-                zelse
-                    dey
-                    tya
                 zendif
                 clc
                 adc #'A'


### PR DESCRIPTION
Problem: when issuing a DIR command on a drive other than the current one, the latter is used in the listing. Examples:
```console
A>DIR B:
A: ATBASIC  TXT : BEDIT    TXT
A: ASM      TXT
A>
```
```console
B>dir a:hello.pas
B: HELLO    PAS
B>
```

This patch checks if there is a drive number in the user FCB and, if so, uses it instead of the current one:
```console
A>DIR B:
B: ATBASIC  TXT : BEDIT    TXT
B: ASM      TXT
A>
```
