### PR TITLE
Proposal: copy.com: Do not copy system files by default, add /S switch

### DIFF
--- a/apps/copy.c
+++ b/apps/copy.c
@@ -16,6 +16,34 @@ static FCB wildcard_fcb;
 static FCB src_fcb;
 static FCB dest_fcb;
 static uint16_t buffer_size;
+static char* cmdptr = cpm_cmdline;
+static bool s_flag = false;
+
+static const char* getword()
+{
+	const char* word = cmdptr;
+	if (*cmdptr)
+	{
+		while (*cmdptr == ' ')
+			cmdptr++;
+
+		for (;;)
+		{
+			char c = *cmdptr;
+			if (!c)
+				break;
+			if (c == ' ')
+			{
+				*cmdptr++ = '\0';
+				break;
+			}
+
+			cmdptr++;
+		}
+	}
+
+	return word;
+}
 
 static void cr(void)
 {
@@ -77,7 +105,7 @@ static void copy_file(void)
 
 	src_fcb.ex = 0;
 	src_fcb.cr = 0;
-	if (cpm_open_file(&src_fcb))
+	if (cpm_open_file(&src_fcb) || ((src_fcb.f[9] & 0x80) && !s_flag))
 	{
 		cr();
 		fatal("cannot open source file");
@@ -122,8 +150,40 @@ static void copy_file(void)
 	cr();
 }
 
+void parse_cmdline()
+{
+	const char *arg;
+
+	cpm_fcb.f[0] = ' ';
+	cpm_fcb2.f[0] = ' ';
+
+	while (*(arg = getword()))
+	{
+		if ('/' == *arg)
+		{
+			if('S' == *++arg)
+				++s_flag;
+			else
+				fatal("Invalid switch");
+		}
+		else if (cpm_fcb.f[0] == ' ')
+		{
+			cpm_set_dma(&cpm_fcb);
+			cpm_parse_filename(arg);
+		}
+		else if (cpm_fcb2.f[0] == ' ')
+		{
+			cpm_set_dma(&cpm_fcb2);
+			cpm_parse_filename(arg);
+			break;
+		}
+	}
+}
+
 int main()
 {
+	parse_cmdline();
+
 	if (cpm_fcb.f[0] == ' ')
 		fatal("source must contain a filename");
 	if (has_wildcard(&cpm_fcb2))
@@ -146,7 +206,8 @@ int main()
 		while (i != 0xff)
 		{
 			FCB* dire = (FCB*) (cpm_default_dma + i*32);
-			*--stash = *dire;
+			if (!(dire->f[9] & 0x80) || s_flag)
+				*--stash = *dire;
 
 			i = cpm_findnext(&wildcard_fcb);
 		}

--- a/src/arch/osi/build.py
+++ b/src/arch/osi/build.py
@@ -328,10 +328,12 @@ mkcpmfs(
         "0:ccp.sys@sr": "src+ccp",
         "0:bdos.sys@sr": "src/bdos",
         "0:tty630.com": "src/arch/osi/utils+tty630",
+        "0:pint.com": "third_party/pascal-m+pint",
+        "0:pasc.obb": "third_party/pascal-m+pasc-obb",
+        "0:pload.com": "third_party/pascal-m+loader",
     }
     | MINIMAL_APPS
     | BIG_APPS
-    | PASCAL_APPS
     | SCREEN_APPS
     | BIG_SCREEN_APPS
 )
@@ -341,6 +343,7 @@ mkcpmfs(
     format="osi5_80",
     size=128 * 1280,
     items={
+        "0:hello.pas": "cpmfs+hello_pas_cpm",
     }
     | MINIMAL_APPS_SRCS
     | BIG_APPS_SRCS


### PR DESCRIPTION
Copying system files may not have the result that the user wants, in particular if those files are `ccp.sys` or `bdos.sys`. What I propose is to exclude system files by default and add a `/S` switch if the user really want to copy them. Example:
```
A> COPY CCP.SYS B:
Copying CCP.SYS -> B:CCP.SYS:
Error: cannot open source file

A> COPY /S CCP.SYS B:
Copyying CCP.SYS -> B:CCP.SYS: rrrrrrrrrrrrrrrrrwwwwwwwwwwwwwwww

A>
```

If using wildcards, the system files are silently removed from the file stash if `/S` is not specified.
