### PR TITLE
[KIM-1]: TTY driver and K-1013 improvements

### DIFF
--- a/src/arch/kim-1/k-1013.S
+++ b/src/arch/kim-1/k-1013.S
@@ -30,13 +30,10 @@ zproc fdc_exec_recal, .text.fdc_exec_recal
 
     ldx #fdc_recal-fdc_commands ; Command index into X
     jsr fdc_exec_command
-    zif_cs
-1:      pla
-        rts
-    zendif
+    bcs fdc_pla_ret
 
     jsr fdc_exec_senseint
-    bcs 1b
+    bcs fdc_pla_ret
 
     ; Compare cylinder number with desired one in ST1
 
@@ -47,6 +44,11 @@ zproc fdc_exec_recal, .text.fdc_exec_recal
         rts
     zendif
     clc
+    rts
+zendproc
+
+zproc fdc_pla_ret, .text.fdc_pla_ret, local
+    pla
     rts
 zendproc
 
@@ -65,10 +67,10 @@ zproc fdc_exec_seek, .text.fdc_exec_seek
 
     ldx #fdc_seek-fdc_commands  ; Command index into X
     jsr fdc_exec_command
-    bcs 1b
+    bcs fdc_pla_ret
 
     jsr fdc_exec_senseint
-    bcs 1b
+    bcs fdc_pla_ret
 
     ; Compare cylinder number with desired one in ST1
 
@@ -235,14 +237,30 @@ zendproc
 ; Command index in X
 
 zproc fdc_exec_command, .text.fdc_exec_command, local
-    lda MSTR                ; Load Main Status Register
-    and #0x10               ; Check if busy
-    bne fdc_fail
+    zloop
+        lda #0x10           ; Check if uPD765 is busy processing a command
+        and MSTR            ;   (should not occur, but happens)
+        zbreakif_eq         ; Not busy, go execute command
+                            ; Yes, execute recovery procedure
+        zrepeat
+            bit MSTR        ; wait until ready to read or write
+        zuntil_mi
+
+        zif_vc              ; Data register ready to write
+            lda #$00        ; Try to complete command sequence
+            sta DATR
+            beq 1f          ; And try again
+        zendif
+                            ; Else, data register needs to be read
+        lda DATR            ; Read status register
+1:      nop                 ; Wait a few cycles
+        nop
+    zendloop
 
     ldy fdc_commands, x     ; Load command length
     inx
 
-    zloop
+    zrepeat
         zrepeat
             lda MSTR        ; Wait until RQM from controller
         zuntil_mi
@@ -273,8 +291,8 @@ zproc fdc_read_result, .text.fdc_read_result, local
         inx                 ; Next byte
         nop                 ; Give the controller time to update
         nop                 ; the MSTR with a valid busy status
-        lda #0x40           ; Check if still talking and go get another
-        and MSTR            ; byte while so
+        lda MSTR            ; Check if still busy and get next
+        and #0x10           ; byte while so
     zuntil_eq
 
     clc

--- a/src/arch/kim-1/kim-1.S
+++ b/src/arch/kim-1/kim-1.S
@@ -146,48 +146,37 @@ zendproc
 
 zproc tty_conin
     lda pending_key
-    zif_eq
-        sty tmp1        ; Save Y
-        lda SBD         ; Supress echo
-        and #0xfe
-        sta SBD
-        jsr GETCH
-        pha
-        lda SBD         ; Restore echo
-        ora #1
-        sta SBD
-        pla
-        cmp #0x20       ; Echo control characters
-        zif_cc
-            pha
-            jsr OUTCH
-            pla
-        zendif
-        ldy tmp1        ; Restore Y
-    zendif
-    ldx #0
-    stx pending_key
+    bne 1f
 
-    cmp #20             ; DEL
-    zif_eq
-        lda #8
-    zendif
+    lda SBD             ; Supress echo
+    and #0xfe
+    sta SBD
+
+    jsr _tty_bgetch
+
+    pha                 ; Restore echo
+    lda SBD
+    ora #1
+    sta SBD
+    pla
+
+1:  ldy #0
+    sty pending_key
 
     clc
     rts
 zendproc
 
 zproc tty_conout
-    sty tmp1            ; Save Y
-    cmp #'\n'
+    cmp #127
     zif_eq
-        pha
-        lda #'\r'
+        lda #8
         jsr OUTCH
-        pla
+        lda #' '
+        jsr OUTCH
+        lda #8
     zendif
     jsr OUTCH
-    ldy tmp1            ; Restore Y
     clc
     rts
 zendproc
@@ -195,7 +184,7 @@ zendproc
 zproc tty_const
     lda pending_key
     zif_eq
-        jsr tty_nbgetch
+        jsr _tty_nbgetch
         sta pending_key
         zif_eq
             clc
@@ -208,18 +197,36 @@ zproc tty_const
     rts
 zendproc
 
+; Blocking tty read. Wait until char ready, then
+; put it into A
+
+zproc _tty_bgetch
+    lda #1
+    zrepeat
+        bit SAD         ; Check start bit
+        bne 1f
+    zuntil_pl
+    bpl _tty_getch      ; Always jump
+1:  lda #0
+    rts
+zendproc
+
 ; Non-blocking tty read. If there is a char ready,
 ; put it into A. Otherwise, return 0x00. Adapted
 ; from the KIM-1 ROM
 
-zproc tty_nbgetch
-    sty tmp1            ; Save XY
-    stx tmp2
-    ldx #8              ; Set up 8 bit count
+zproc _tty_nbgetch
     lda #1
     bit SAD             ; Check start bit
-    bne 1f
-    bmi 1f              ; No start bit
+    bne 1b
+    bmi 1b              ; No start bit
+zendproc
+;
+; Fall through
+;
+zproc _tty_getch
+    ldx #8              ; Set up 8 bit count
+    lda #1
     jsr DELAY           ; Delay 1 bit
     jsr DEHALF          ; Delay 1/2 bit time
     zrepeat             ; Get 8 bits loop
@@ -235,10 +242,6 @@ zproc tty_nbgetch
     lda CHAR
     rol a               ; Shift off parity
     lsr a
-    bne 2f
-1:  lda #0
-2:  ldx tmp2            ; Restore XY
-    ldy tmp1
     rts
 zendproc
 

--- a/src/arch/kim-1/utils/format.S
+++ b/src/arch/kim-1/utils/format.S
@@ -398,13 +398,10 @@ zproc fdc_exec_recal
 
     ldx #fdc_recal-fdc_commands ; Command index into X
     jsr fdc_exec_command
-    zif_cs
-1:      pla
-        rts
-    zendif
+    bcs fdc_pla_ret
 
     jsr fdc_exec_senseint
-    bcs 1b
+    bcs fdc_pla_ret
 
     ; Compare cylinder number with desired one in ST1
 
@@ -415,6 +412,11 @@ zproc fdc_exec_recal
         rts
     zendif
     clc
+    rts
+zendproc
+
+zproc fdc_pla_ret
+    pla
     rts
 zendproc
 
@@ -433,10 +435,10 @@ zproc fdc_exec_seek
 
     ldx #fdc_seek-fdc_commands  ; Command index into X
     jsr fdc_exec_command
-    bcs 1b
+    bcs fdc_pla_ret
 
     jsr fdc_exec_senseint
-    bcs 1b
+    bcs fdc_pla_ret
 
     ; Compare cylinder number with desired one in ST1
 
@@ -521,6 +523,28 @@ zproc fdc_exec_format
     rts
 zendproc
 
+zproc fdc_read_result
+    ldx #0
+    zloop
+        zrepeat
+            lda MSTR        ; Wait until RQM from controller
+        zuntil_mi
+        and #0x40           ; Test data direction bit
+        beq fdc_fail        ; Error if controller wants to listen
+
+        lda DATR            ; Get status byte from data register
+        sta disk_status, x  ; Put it into memory
+        inx                 ; Next byte
+        nop                 ; Give the controller time to update
+        nop                 ; the MSTR with a valid busy status
+        lda MSTR            ; Check if still busy and get next
+        and #0x10           ; byte while so
+    zuntil_eq
+
+    clc
+    rts
+zendproc
+
 zproc fdc_fail
     sec
     rts
@@ -584,9 +608,25 @@ zendproc
 ; Command index in X
 
 zproc fdc_exec_command
-    lda MSTR                ; Load Main Status Register
-    and #0x10               ; Check if busy
-    bne fdc_fail
+    zloop
+        lda #0x10           ; Check if uPD765 is busy processing a command
+        and MSTR            ;   (should not occur, but happens)
+        zbreakif_eq         ; Not busy, go execute command
+                            ; Yes, execute recovery procedure
+        zrepeat
+            bit MSTR        ; wait until ready to read or write
+        zuntil_mi
+
+        zif_vc              ; Data register ready to write
+            lda #$00        ; Try to complete command sequence
+            sta DATR
+            beq 1f          ; And try again
+        zendif
+                            ; Else, data register needs to be read
+        lda DATR            ; Read status register
+1:      nop                 ; Wait a few cycles
+        nop
+    zendloop
 
     ldy fdc_commands, x     ; Load command length
     inx
@@ -602,28 +642,6 @@ zproc fdc_exec_command
         sta DATR            ; Store into FDC data register
         inx                 ; Next command byte
         dey
-    zuntil_eq
-
-    clc
-    rts
-zendproc
-
-zproc fdc_read_result
-    ldx #0
-    zloop
-        zrepeat
-            lda MSTR        ; Wait until RQM from controller
-        zuntil_mi
-        and #0x40           ; Test data direction bit
-        beq fdc_fail        ; Error if controller wants to listen
-
-        lda DATR            ; Get status byte from data register
-        sta disk_status, x  ; Put it into memory
-        inx                 ; Next byte
-        nop                 ; Give the controller time to update
-        nop                 ; the MSTR with a valid busy status
-        lda #0x40           ; Check if still talking and go get another
-        and MSTR            ; byte while so
     zuntil_eq
 
     clc


### PR DESCRIPTION
There are two commits:

* Add a recovery procedure in case of FDC failure for the K-1013 variant. This should give improved reliability.
* Manage `BS` and `DEL` correctly in the TTY driver and remove `NL` to `CRNL` translation in `tty_conout`. Also, remove useless `X`and `Y` registers preservation.

Thanks! 