### PR TITLE
[Pascal-M] Implement read/readln into strings

### DIFF
--- a/third_party/pascal-m/cpascalm2k1.pas
+++ b/third_party/pascal-m/cpascalm2k1.pas
@@ -3322,27 +3322,37 @@ read -->----------------( ( )----( file-ident )------          !
                        !      --------------------     !
                        !                               !
                         --------------<----------------          *)
+        var
+          lsp : structptr ;
+
           procedure ProcessTerms;
           var
             test: boolean;
+            len : addrrange ;
+
 
           begin
             repeat
+              lsp := gattr.typtr ;
               begin
                 if (gattr.kind <> varbl) then
                   Error(154);
                       (* place address of variable
-                          on stack for rdc or rdi *)
+                          on stack for rdc, rdi or rds *)
                 LoadAddress ;
-                if (gattr.typtr <> nil)
+                if (lsp <> nil)
                 then
                 begin
-                  if CompTypes(intptr, gattr.typtr) then
+                  if CompTypes(intptr, lsp) then
                     CSPgen(3) (* rdi *)
-                  else if CompTypes(charptr, gattr.typtr) then
+                  else if CompTypes(charptr, lsp) then
                     CSPgen(5) (* rdc *)
-                  else if IsString(gattr.typtr) then
-                    CSPgen(4) (* rdn *)
+                  else if IsString(lsp) then
+                  begin
+                    len := lsp^.size;
+                    LDCIGen(len);
+                    CSPgen(19) (* rds *)
+                  end
                   else
                     Error(177);
                 end

--- a/third_party/pascal-m/pascalmint2k1.S
+++ b/third_party/pascal-m/pascalmint2k1.S
@@ -2391,11 +2391,7 @@ wrt1:   clc
 
 ttyout:
         txa
-        cmp #CR
-        bne ttyout1
         jsr bdos_CONOUT
-        lda #LF
-ttyout1:jsr bdos_CONOUT
         ldy ytmp
         rts
 

--- a/third_party/pascal-m/pascalmint2k1.S
+++ b/third_party/pascal-m/pascalmint2k1.S
@@ -269,6 +269,7 @@ incpca: rts
         ;
         ; to HEX
         ;
+#if 0                   // Dead code, not referenced elsewhere
 hexit:  cmp #$3A
         php
         and #$0F
@@ -276,6 +277,7 @@ hexit:  cmp #$3A
         bcc hexit1      ; 0 .. 9
         adc #$08         
 hexit1: rts
+#endif
         ;
         ; stack operations PULL and PUSH
         ; PULL2 and PUSH2
@@ -2471,6 +2473,7 @@ writepc: lda #' '
         lda #13
         jmp bdos_CONOUT
 
+#if 0                  // enable for tracing
 writesp: lda #'~'
         jsr bdos_CONOUT
 
@@ -2478,6 +2481,7 @@ writesp: lda #'~'
         jsr phex2
         lda stack
         jmp phex2
+#endif
 
 con_cr:
         lda #<crlf_msg

--- a/third_party/pascal-m/pascalmint2k1.S
+++ b/third_party/pascal-m/pascalmint2k1.S
@@ -1491,6 +1491,7 @@ csptab: .word   wri         ;  0 write integer
         .word   clsf        ; 10 close file
         .word   asnf        ; 11 assign file
         .word   getparams   ; 12 get command line parameters
+        .word   rds         ; 13 read string
         ;
         ; BE CUP1
         ;
@@ -1908,6 +1909,7 @@ stp:    jmp bdos_EXIT       ; just stop
         ; routines
         ;
 getch:  
+        sty ytmp
         jsr rdt         ; read from input
         cmp #$20            ; printable?
         bcc getch2
@@ -1915,6 +1917,7 @@ getch:
         beq getch           ; ignore rubout
         ldy #$00            ; no EOLN flag
 getch1: sty eolb
+        ldy ytmp
         rts
 getch2: cmp #LF             ; LF, then fake space and EOLN true
         bne getch3          ; ignore other control chars except OF
@@ -2046,6 +2049,24 @@ getparams1:
         ldy #0
         sta (tmp2l2), y
         jmp interpr
+        ;
+        ; PROC 13 RDS
+        ;
+rds:    jsr setup2          ; Pointer to string in tmp2l2, size in tmp3l2
+        ldy #$ff            ; Init string index
+rds1:   iny                 ; Increment index
+        cpy tmp3l2
+        bcs rds3            ; No space left in string
+        jsr getch           ; Get netx char
+        sta (tmp2l2),y
+        ldx eolb            ; eol set?
+        beq rds1            ; No, next char
+rds2:   iny                 ; Fill with spaces
+        cpy tmp3l2
+        bcs rds3
+        sta (tmp2l2),y
+        bcc rds2
+rds3:   jmp interpr
         ;
         ; MUL10 multiply tmp1l8 by 10
 mul10:  asl tmp1l8
@@ -2276,8 +2297,7 @@ compa4: incr tmp2l2
 ;
 ; Read one char from TTY without the KIM hardware echo
 ;
-rdt:	sty ytmp
-        lda fa+1
+rdt:	lda fa+1
         beq ttyin
 
         ldy #FP_POS
@@ -2309,16 +2329,21 @@ rdt1:   clc
         sta (fa), y
         pla
 
-        ldy ytmp
         rts
 
 rdeof:  lda #$1a
-        ldy ytmp
         rts
 
 ttyin:  jsr bdos_CONIN
-        ldy ytmp
-        rts
+        cmp #CR
+        bne ttyin1
+        lda #LF
+ttyin1: cmp #LF
+        bne ttyin2
+        pha 
+        jsr con_cr              ; Echo when EOL
+        pla
+ttyin2: rts
 ; 
 ; Write one char to TTY
 ;


### PR DESCRIPTION
Fixes issue #226.

Implemented a new procedure, `rds`, which takes the string size and a pointer to the string, reads characters until `EOL`, `EOF` or string size and fills the remaining space with blanks (spaces). This implementation is flawed because it assumes that the size of the string is less that 256, so dimensioning the string to greater values will have undesirable effects (lenght will be checked just against the LSB). I haven't done anything more elaborated because that is what wrs also does. Maybe we should open an issue to address that.

I've opted for filling with spaces if the input is smaller than the array size. Would leaving the rest of the array contents untouched be better?