### PR TITLE
mkfs: Do a CRLF instead of just LF

### DIFF
--- a/apps/mkfs.c
+++ b/apps/mkfs.c
@@ -135,12 +135,12 @@ void main(void)
 
     print("About to create a filesystem on drive ");
     cpm_conout(cpm_fcb.dr + '@');
-    printx(",\ndestroying everything on it.");
+    printx(",\r\ndestroying everything on it.");
     print("Press Y to proceed, anything else to cancel: ");
     if (cpm_conin() != 'y')
         fatal("Aborted.");
 
-    printx("\nFormatting now...");
+    printx("\r\nFormatting now...");
 
     cpm_bios_setdma(cpm_default_dma);
     memset(cpm_default_dma, 0xe5, 128);


### PR DESCRIPTION
Just cosmetic, but annoying if your terminal doesn't do `CR -> CRLF` conversion:

```
B>mkfs a:
Drive A:
  Number of reserved sectors: 52
  Number of directory blocks: 2
  Size of block:              2048 bytes
  Number of blocks:           250
  Total disk size:            506 kB

About to create a filesystem on drive A,
                                        destroying everything on it.
Press Y to proceed, anything else to cancel: y
                                              Formatting now...
Done.
```
