### PR TITLE
OSI Overscan area

### DIFF
--- a/src/arch/osi/osi.S
+++ b/src/arch/osi/osi.S
@@ -58,21 +58,41 @@ drive_number:   .fill 1
 sector_num:     .fill 3
 dma:            .fill 2
 
+; Invisible overscan areas:
+;
+; 32x32 --> 24x26 worst case, hidden: 6L, 2R, 3T, 3B
+; 64x32 --> 48x26 worst case, hidden: 13L, 3R, 3T, 3B
+; 64x16 --> 48x12 worst case, hidden: 13L, 3R, 2T, 2B
+
 #if OSI400
-    SCREEN_WIDTH  = 32
-    SCREEN_HEIGHT = 32
-    SCREEN_PAGES  = 4
+    XSCREEN_WIDTH  = 32
+    XSCREEN_HEIGHT = 32
+    XSCREEN_PAGES  = 4
+    SCREEN_WIDTH   = 24
+    SCREEN_HEIGHT  = 26
+    SCREEN_LMARGIN = 6
+    SCREEN_TMARGIN = 3
 #elif OSI500
-    SCREEN_WIDTH  = 64
-    SCREEN_HEIGHT = 32
-    SCREEN_PAGES  = 8
+    XSCREEN_WIDTH  = 64
+    XSCREEN_HEIGHT = 32
+    XSCREEN_PAGES  = 8
+    SCREEN_WIDTH   = 48
+    SCREEN_HEIGHT  = 26
+    SCREEN_LMARGIN = 13
+    SCREEN_TMARGIN = 3
     CONTROL = $de00
 #elif OSI600
-    SCREEN_WIDTH  = 64
-    SCREEN_HEIGHT = 16
-    SCREEN_PAGES  = 4
+    XSCREEN_WIDTH  = 64
+    XSCREEN_HEIGHT = 16
+    XSCREEN_PAGES  = 4
+    SCREEN_WIDTH   = 48
+    SCREEN_HEIGHT  = 12
+    SCREEN_LMARGIN = 13
+    SCREEN_TMARGIN = 2
     CONTROL = $d800
 #endif
+
+#define SCREEN_HOMEPOS_OFFSET SCREEN_LMARGIN+(SCREEN_TMARGIN * XSCREEN_WIDTH)
 
 #ifdef FLOPPY8
 PAGES_PER_TRACK = 12
@@ -105,7 +125,7 @@ init:
 
     lda #>SCREENMEM
     sta ptr+1
-    ldx #SCREEN_PAGES
+    ldx #XSCREEN_PAGES
     lda #' '
 
     zloop                   ; clear screen
@@ -413,16 +433,25 @@ zproc calculate_cursor_address
         inc ptr+1
     zendif
 
+    lda ptr
+    clc
+    adc #SCREEN_HOMEPOS_OFFSET  ; offset is always < 256
+    sta ptr
+    zif_cs
+        inc ptr+1
+    zendif
     rts
 zendproc
 
 zproc scroll_up
-    lda #<(SCREENMEM)
+    lda #<(SCREENMEM+SCREEN_TMARGIN*XSCREEN_WIDTH)
     sta ptr
-    lda #<(SCREENMEM+SCREEN_WIDTH)
-    sta ptr1
-    lda #>SCREENMEM
+    lda #>(SCREENMEM+SCREEN_TMARGIN*XSCREEN_WIDTH)
     sta ptr+1
+
+    lda #<(SCREENMEM+(SCREEN_TMARGIN+1)*XSCREEN_WIDTH)
+    sta ptr1
+    lda #>(SCREENMEM+(SCREEN_TMARGIN+1)*XSCREEN_WIDTH)
     sta ptr1+1
 
     ldy #0
@@ -438,14 +467,14 @@ zproc scroll_up
             inc ptr1+1
         zendif
         lda ptr1+1
-        cmp #>(SCREENMEM+SCREEN_PAGES*256)
+        cmp #>(SCREENMEM+XSCREEN_PAGES*256)
     zuntil_eq
 
     lda #' '
     zloop                       ; Clear last line
         sta (ptr),y
         iny
-        cpy #SCREEN_WIDTH
+        cpy #XSCREEN_WIDTH
     zuntil_eq
 
     rts

--- a/src/arch/osi/utils/tty540b.S
+++ b/src/arch/osi/utils/tty540b.S
@@ -27,10 +27,21 @@ cury:       .fill 1
 
 drv_zp_end:
 
+; Invisible overscan areas:
+;
+; 64x32 --> 48x26 worst case, hidden: 13L, 3R, 3T, 3B
+; 64x16 --> 48x12 worst case, hidden: 13L, 3R, 2T, 2B
+
 #if OSI630
 
-SCREEN_WIDTH = 64
-SCREEN_HEIGHT = 16
+XSCREEN_WIDTH = 64
+XSCREEN_HEIGHT = 16
+
+SCREEN_WIDTH   = 48
+SCREEN_HEIGHT  = 12
+SCREEN_LMARGIN = 13
+SCREEN_TMARGIN = 2
+SCREEN_BMARGIN = 2
 
 CONTROL = $d800
 
@@ -42,16 +53,24 @@ INVERSE   = $01
 CURSORXOR = (NORMAL ^ INVERSE)
 
 SCREENMEM   = $d000
-SECLASTLINE = $d380
-LASTLINE    = $d3c0
+SECLASTLINE = $d380 - SCREEN_BMARGIN*XSCREEN_WIDTH + SCREEN_LMARGIN
+LASTLINE    = $d3c0 - SCREEN_BMARGIN*XSCREEN_WIDTH + SCREEN_LMARGIN
+FIRSTLINE   = $d000 + SCREEN_TMARGIN*XSCREEN_WIDTH + SCREEN_LMARGIN
+SECLINE     = $d040 + SCREEN_TMARGIN*XSCREEN_WIDTH + SCREEN_LMARGIN
 
 COLORMEM    = $d400
 COLORXOR    = ((SCREENMEM ^ COLORMEM) / 256)
 
 #else
 
-SCREEN_WIDTH = 64
-SCREEN_HEIGHT = 32
+XSCREEN_WIDTH = 64
+XSCREEN_HEIGHT = 32
+
+SCREEN_WIDTH   = 48
+SCREEN_HEIGHT  = 26
+SCREEN_LMARGIN = 13
+SCREEN_TMARGIN = 3
+SCREEN_BMARGIN = 3
 
 CONTROL = $de00
 
@@ -63,13 +82,17 @@ INVERSE   = $0f
 CURSORXOR = (NORMAL ^ INVERSE)
 
 SCREENMEM   = $d000
-SECLASTLINE = $d780
-LASTLINE    = $d7c0
+SECLASTLINE = $d780 - SCREEN_BMARGIN*XSCREEN_WIDTH + SCREEN_LMARGIN
+LASTLINE    = $d7c0 - SCREEN_BMARGIN*XSCREEN_WIDTH + SCREEN_LMARGIN
+FIRSTLINE   = $d000 + SCREEN_TMARGIN*XSCREEN_WIDTH + SCREEN_LMARGIN
+SECLINE     = $d040 + SCREEN_TMARGIN*XSCREEN_WIDTH + SCREEN_LMARGIN
 
 COLORMEM    = $e000
 COLORXOR    = ((SCREENMEM ^ COLORMEM) / 256)
 
 #endif
+
+#define SCREEN_HOMEPOS_OFFSET SCREEN_LMARGIN+(SCREEN_TMARGIN * XSCREEN_WIDTH)
 
 ; -------------------------------------------------------------------------
 
@@ -317,7 +340,7 @@ stylebg=.+1
     lda #NORMAL
     sta (ptr1),y
 
-    cpy #SCREEN_WIDTH-1
+    cpy #XSCREEN_WIDTH-1
     zif_ne
         inc curx
     zendif
@@ -369,17 +392,20 @@ zproc screen540b_getchar
 zendproc
 
 zproc screen540b_scrollup
-    lda #0
+    lda #<FIRSTLINE
     sta ptr
     sta ptr2
-    lda #SCREEN_WIDTH
-    sta ptr1
-    sta ptr3
-    lda #>SCREENMEM
+    lda #>FIRSTLINE
     sta ptr+1
-    sta ptr1+1
     eor #COLORXOR
     sta ptr2+1
+
+    lda #<SECLINE
+    sta ptr1
+    sta ptr3
+    lda #>SECLINE
+    sta ptr1+1
+    eor #COLORXOR
     sta ptr3+1
 
     ldx #SCREEN_HEIGHT-1
@@ -403,9 +429,8 @@ zproc screen540b_scrollup
 
         lda ptr1
         clc
-        adc #SCREEN_WIDTH
+        adc #XSCREEN_WIDTH
         sta ptr1
-        sta ptr3
         zif_cs
             inc ptr1+1
             inc ptr3+1
@@ -435,11 +460,13 @@ zproc screen540b_scrolldown
     sta ptr
     sta ptr2
     lda #>LASTLINE
-    sta ptr1+1
     sta ptr+1
     eor #COLORXOR
-    sta ptr3+1
     sta ptr2+1
+    lda #>SECLASTLINE
+    sta ptr1+1
+    eor #COLORXOR
+    sta ptr3+1
 
     ldx #SCREEN_HEIGHT-1
     zloop
@@ -462,7 +489,7 @@ zproc screen540b_scrolldown
 
         lda ptr1
         sec
-        sbc #SCREEN_WIDTH
+        sbc #XSCREEN_WIDTH
         sta ptr1
         sta ptr3
         zif_cc
@@ -591,10 +618,18 @@ zproc calculate_cursor_address
     adc #>SCREENMEM     ; only MSB because SCREENMEM is page aligned
     sta ptr+1
 
+    lda ptr
+    clc
+    adc #SCREEN_HOMEPOS_OFFSET  ; offset is always < 256
+    sta ptr
+    sta ptr1
+    zif_cs
+        inc ptr+1
+    zendif
+
+    lda ptr+1
     eor #COLORXOR
     sta ptr1+1
-    lda ptr
-    sta ptr1
 
     rts
 zendproc


### PR DESCRIPTION
Updated both the default TTY driver, and the 540b and 630 screen drivers to take the overscan area into account. I got feedback about invisible text on real hardware :wink:

500 series with 540B screen driver:
![mbrot-osi540b](https://github.com/user-attachments/assets/5cc64dd0-1395-42c3-aec8-0f5060acdc7f)

600 series with 630 screen driver:
![mbrot-osi630](https://github.com/user-attachments/assets/0785ef4e-cf01-4ee1-a908-d6147d4b0f8d)

and the 400 series' 32x32 becomes 24x26 which is really narrow, but still works:
![osi400-overscan](https://github.com/user-attachments/assets/6db66efd-377a-4f11-aadc-d87e4f36b193)
