### PR TITLE
KIM-1 port with Corsham's SD Shield

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -47,6 +47,7 @@ jobs:
           images/kim-1-iec.zip
           images/kim-1-k1013.zip
           images/kim-1-sdcard.zip
+          images/kim-1-sdshield.zip
           images/neo6502.zip
           images/oric.dsk
           images/osi400f.os8

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
           kim-1-iec.zip
           kim-1-k1013.zip
           kim-1-sdcard.zip
+          kim-1-sdshield.zip
           nano6502.img
           nano6502_sysonly.img
           neo6502.zip
@@ -100,6 +101,7 @@ jobs:
           cpm65/images/kim-1-iec.zip
           cpm65/images/kim-1-k1013.zip
           cpm65/images/kim-1-sdcard.zip
+          cpm65/images/kim-1-sdshield.zip
           cpm65/images/nano6502.img
           cpm65/images/nano6502_sysonly.img
           cpm65/images/neo6502.zip

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ to the 6502. So far it runs on:
 
   - nano6502 6502-based SoC for the Tang Nano 20K FPGA board; TPA is 55kB.
 
-  - KIM-1 with K-1013 FDC, directly connected SD card module or 1541 drive.
+  - KIM-1 with K-1013 FDC, directly connected SD card module, 1541 drive or Corsham's SD Shield.
 
   - Ohio Scientific series with 16kB RAM or more, and a floppy drive. TPA up to 39kB.
 
@@ -378,11 +378,9 @@ the same time.
 
 ### KIM-1 with K-1013 FDC notes
 
-  - To run this on an KIM-1, you need an MTU K-1013 Floppy Disk Controller with an
-    SSDD 8'' disk (or this [Pico based RAM/ROM/Video/FDC card](https://github.com/eduardocasino/kim-1-programmable-memory-card)) and full RAM upgrade, including the
-    0x0400-0x13ff memory hole.
+  - To run this on an KIM-1, you need an MTU K-1013 Floppy Disk Controller with an SSDD 8'' disk (or this [Pico based RAM/ROM/Video/FDC card](https://github.com/eduardocasino/kim-1-programmable-memory-card)) and full RAM upgrade, including the 0x0400-0x13ff memory hole.
 
-  - To use it, transfer the `diskimage.imd` image to an SSDD 8'' disk (or place it directly onto an FAT or exFAT formatted SD card and assign it to disk0 in the Pico card). Start the KIM-1 in TTY mode, load the `boot.pap` loader program into 0x0200 and execute it.
+  - To use it, transfer the `diskimage.imd` image to an SSDD 8'' disk (or place it directly onto a FAT or exFAT formatted SD card and assign it to disk0 in the Pico card). Start the KIM-1 in TTY mode, load the `boot.pap` loader program into `0x0200` and execute it.
 
   - Up to 4 disks are supported.
 
@@ -407,6 +405,27 @@ the same time.
   - 1 32MB disk supported.
 
   - Only TTY interface for now, no SCREEN driver.
+
+### KIM-1 with Corsham's SD Shield notes
+
+  - For this port, you'll need an original Corsham's SD Shield, [a clone like this one](https://github.com/eduardocasino/sd-card-shield) or even this [Raspberry Pi Pico based variant](https://retro-spy.com/product/sd-card-system/).
+
+  - Place the `CPM-BOOT.DSK` image at the root of a FAT32 formatted SD card and create an `SD.CFG`file with this content:
+    ```
+    0:CPM-BOOT.DSK
+    ```
+
+  - Start the KIM-1 in TTY mode, load the `bootsdshield.pap` loader program into `0x0200` and execute it.
+
+  - As for the SD variant above, for KIM-1 clones, you can place the `bootsdshield-kimrom.bin` bootloader into the free space of the KIM-1 rom, starting at 0x1AA0.
+
+  - Same memory requirements as for the SD variant.
+
+  - Up to 4 disks are supported.
+
+  - Only TTY interface for now, no SCREEN driver.
+
+  - An Image Manipulation Utility, `IMU.COM`, is included. It allows mounting and unmounting disk images and, [with the latest SD Shield firmware](https://github.com/eduardocasino/SD-drive/tree/version-2), even copy, rename, delete or create new ones.
 
 ### KIM-1 with Commodore 1541 drive
 

--- a/build.py
+++ b/build.py
@@ -54,6 +54,7 @@ export(
         "images/kim-1-k1013.zip": "src/arch/kim-1+distro-k1013",
         "images/kim-1-sdcard.zip": "src/arch/kim-1+distro-sdcard",
         "images/kim-1-iec.zip": "src/arch/kim-1+distro-iec",
+        "images/kim-1-sdshield.zip": "src/arch/kim-1+distro-sdshield",
     },
     deps=["tests"],
 )

--- a/src/arch/kim-1/boot/boot-kimrom.ld
+++ b/src/arch/kim-1/boot/boot-kimrom.ld
@@ -1,6 +1,6 @@
 MEMORY {
     zp : ORIGIN = 0x00, LENGTH = 0xef
-	ram (rw) : ORIGIN = 0x1aa0, LENGTH = 0x1200
+	ram (rw) : ORIGIN = 0x1aa0, LENGTH = 0x15a
 }
 
 SECTIONS {

--- a/src/arch/kim-1/boot/bootsdshield.S
+++ b/src/arch/kim-1/boot/bootsdshield.S
@@ -1,0 +1,377 @@
+; CP/M-65 boot program for the KIM-1
+; Copyright © 2024 Eduardo Casino
+; 
+; SD Shield interface code by Bob Applegate
+;
+; This file is licensed under the terms of the 2-clause BSD license. Please
+; see the COPYING file in the root project directory for the full text.
+
+; KIM-1 ZP
+
+SPUSER = $f2            ; Current stack pointer
+
+; KIM-1 Variables
+
+CNTH30 = $17f3
+CNTL30 = $17f2
+
+; KIM-1 vectors
+
+NMIV = $17fa            ; Stop vector (STOP=1C00)
+IRQV = $17fe            ; IRQ vector  (BRK=1C00)
+
+; KIM-1 functions
+
+INITS  = $1e88          ; Initialization for sigma
+PRTBYT = $1e3b          ; print A as two hex digits
+OUTCH  = $1ea0          ; print A to TTY
+CRLF   = $1e2f          ; print CR/LF
+
+;----------------------------------------------------
+; Bits in the B register
+;
+DIRECTION = 1<<0    ;%00000001
+PSTROBE   = 1<<1    ;%00000010
+ACK       = 1<<2    ;%00000100
+
+;----------------------------------------------------
+; The KIM has a 6530 with the two I/O ports at $1700.
+;
+; Addresses of 6530 registers
+;
+PIABASE = $1700
+PIAREGA = PIABASE       ;data reg A
+PIADDRA = PIABASE+1     ;data dir reg A
+PIAREGB = PIABASE+2     ;data reg B
+PIADDRB = PIABASE+3     ;data dir reg B
+
+;=====================================================
+; Commands from host to Arduino
+;
+PC_RD_SECTOR    = $18       ;Read FLEX sector
+
+;=====================================================
+; Responses from Arduino to host
+;
+PR_SECTOR_DATA  = $94       ;Sector data
+
+.section .zp, "zax", @nobits
+
+zp_sds_dpb:
+zp_sds_drive:           .fill 1
+zp_sds_track:           .fill 1
+zp_sds_sector:          .fill 1
+zp_sds_spt:             .fill 1     ; Sectors per track
+zp_sds_buffer:          .fill 2     ; Pointer to data buffer
+
+.text
+
+.global _start
+_start:
+
+#ifdef KIM_ROM
+
+    ; Reset entry point
+rst:
+    ldx #0xff
+    txs
+    stx SPUSER
+    jsr INITS
+
+    ; Source: KIM-1/650X USER NOTES, ISSUE #6, July 77
+    ;
+    ; BAUD      110     150     300     600     1200    1800    2400    4800    9600
+    ; CNTH30    $02     $01     $00     $00      $00     $00     $00     $00     $00
+    ; CNTL30    $85     $d8     $eb     $74      $38     $24     $1a     $06     $03
+
+    ; Values for 9600 baud
+
+    lda #$00
+    sta CNTH30
+    lda #$03
+    sta CNTL30
+
+ram_start:
+
+#endif
+    cld
+
+    ; Set interrupt vectors so we can return to the monitor
+
+    lda #$1c
+    sta NMIV+1
+    sta IRQV+1
+
+    lda #0
+    sta NMIV+0
+    sta IRQV+0
+
+    ; Init paralel port
+
+    jsr xParInit
+    
+    ; Load first 8 sectors into $6000 (FIXME: Make this configurable)
+
+    lda #$60
+    sta zp_sds_buffer+1
+    lda #0
+    sta zp_sds_buffer+0
+    sta zp_sds_drive
+    sta zp_sds_track
+    sta zp_sds_sector
+    lda #26                         ; Sectors per track
+    sta zp_sds_spt
+
+    ldx #8
+1:  jsr DiskReadSector
+    bcs error
+    inc zp_sds_sector
+    inc zp_sds_buffer+1
+    dex
+    bne 1b
+
+    jmp $6000
+
+; Error handling
+
+error:
+    ldx #0
+1:  lda errmsg, x
+    beq 2f
+    jsr OUTCH
+    inx
+    bne 1b
+2:  lda zp_sds_sector
+    jsr PRTBYT
+
+    brk
+
+; Error message string
+
+errmsg:
+    .byte 13, 10
+    .ascii "Error reading sector "
+    .byte 0
+
+;=====================================================
+; This is a low level disk function for a real OS to
+; perform a disk sector read.  On entry, zp_sds_dpb
+; is a disk parameter block with the following fields:
+;
+;    drive             DS   1
+;    track             DS   1
+;    sector            DS   1
+;    sectors per track DS   1
+;    ptr to data       DS   2   must be 256 bytes long!
+;
+; The first three fields are zero based.  Sectors per
+; track is a one based value.
+;
+; Returns with C clear on success.  If error, C is set
+; and A contains the error code.
+;
+DiskReadSector:
+    lda #PC_RD_SECTOR           ;sector read command
+	jsr	xParWriteByte	        ;command
+	lda	zp_sds_drive	        ;get drive
+	jsr	xParWriteByte	        ;drive
+	lda	#2	                    ;256 byte sectors
+	jsr	xParWriteByte
+	lda	zp_sds_track	        ;get track
+	jsr	xParWriteByte	        ;track
+	lda	zp_sds_sector	        ;get sector
+    jsr	xParWriteByte	        ;sector
+	lda	zp_sds_spt	            ;get tracks/sector
+    jsr	xParWriteByte
+;
+; Now get the response.  Will be either a NAK followed
+; by an error code, or a 97 followed by 256 bytes of
+; data.
+;
+    jsr xParSetRead
+    jsr xParReadByte        ;response
+    cmp #PR_SECTOR_DATA     ;data?
+    bne DiskCerror          ;no
+
+; Read 256 bytes to the address at zp_sd_address
+
+    ldy #0
+1:  jsr xParReadByte
+    sta (zp_sds_buffer),y
+    iny
+    bne 1b    
+;
+; All done
+;
+    jsr xParSetWrite
+    clc
+    rts
+
+;
+; Common error handler. Set carry, and exit.
+;
+DiskCerror:
+    sec
+    rts
+
+;*****************************************************
+; This is the initialization function.  Call before
+; doing anything else with the parallel port.
+;
+
+;
+; Set up the data direction register for port B so that
+; the DIRECTION and PSTROBE bits are output.  Only touch
+; the bits we're using; leave the rest as-is.
+;
+xParInit:
+    lda PIADDRB        ;get current value
+    and #~ACK & 0xff
+    ora #DIRECTION | PSTROBE
+    sta PIADDRB
+;
+    lda #$ff
+    sta PIADDRA        ;set data for write
+;
+; Now that the data is set, set the direction
+; registers.  This prevents weird problems like
+; driving lines to the wrong state.
+;
+    lda PIAREGB
+    and #~(PSTROBE | ACK) & 0xff
+    ora #DIRECTION
+    sta PIAREGB
+    rts
+
+;*****************************************************
+; This sets up for writing to the Arduino.  Sets up
+; direction registers, drives the direction bit, etc.
+;
+xParSetWrite:
+    lda #$ff            ;set bits for output
+    sta PIADDRA
+;
+; Set direction flag to output, clear ACK bit
+;
+    lda PIAREGB
+    and #~(PSTROBE | ACK) & 0xff
+    ora #DIRECTION
+    sta PIAREGB
+    rts
+
+;*****************************************************
+; This sets up for reading from the Arduino.  Sets up
+; direction registers, clears the direction bit, etc.
+;
+xParSetRead:
+    lda #$00            ;set bits for input
+    sta PIADDRA
+;
+; Set direction flag to input, clear ACK bit
+;
+    lda PIAREGB
+    and #~(DIRECTION | PSTROBE | ACK) & 0xff
+    sta PIAREGB
+    rts
+        
+;*****************************************************
+; This writes a single byte to the Arduino.  On entry,
+; the byte to write is in A.  This assumes ParSetWrite
+; was already called.
+;
+; Destroys A, all other registers preserved.
+;
+; Write cycle:
+;
+;    1. Wait for other side to lower ACK.
+;    2. Put data onto the bus.
+;    3. Set DIRECTION and PSTROBE to indicate data
+;       is valid and ready to read.
+;    4. Wait for ACK line to go high, indicating the
+;       other side has read the data.
+;    5. Lower PSTROBE.
+;    6. Wait for ACK to go low, indicating end of
+;       transfer.
+;
+xParWriteByte:
+    pha                 ;save data
+1:  lda PIAREGB         ;check status
+    and #ACK
+    bne 1b              ;wait for ACK to go low
+
+;
+; Now put the data onto the bus
+;
+    pla
+    sta PIAREGA
+;
+; Raise the strobe so the Arduino knows there is
+; new data.
+;
+    lda PIAREGB
+    ora #PSTROBE
+    sta PIAREGB
+;
+; Wait for ACK to go high, indicating the Arduino has
+; pulled the data and is ready for more.
+;
+2:  lda PIAREGB
+    and #ACK
+    beq 2b
+
+;
+; Now lower the strobe, then wait for the Arduino to
+; lower ACK.
+;
+    lda PIAREGB
+    and #~PSTROBE & 0xff
+    sta PIAREGB
+3:  lda PIAREGB
+    and #ACK
+    bne 3b
+    rts
+
+;*****************************************************
+; This reads a byte from the Arduino and returns it in
+; A.  Assumes ParSetRead was called before.
+;
+; This does not have a time-out.
+;
+; Preserves all other registers.
+;
+; Read cycle:
+;
+;    1. Wait for other side to raise ACK, indicating
+;       data is ready.
+;    2. Read data.
+;    3. Raise PSTROBE indicating data was read.
+;    4. Wait for ACK to go low.
+;    5. Lower PSTROBE.
+;
+xParReadByte:
+    lda PIAREGB
+    and #ACK            ;is their strobe high?
+    beq xParReadByte    ;nope, no data
+;
+; Data is available, so grab and save it.
+;
+    lda PIAREGA
+    pha
+;
+; Now raise our strobe (their ACK), then wait for
+; them to lower their strobe.
+;
+    lda PIAREGB
+    ora #PSTROBE
+    sta PIAREGB
+1:  lda PIAREGB
+    and #ACK
+    bne 1b              ;still active 
+;
+; Lower our ack, then we're done.
+;
+    lda PIAREGB
+    and #~PSTROBE & 0xff
+    sta PIAREGB
+    pla
+    rts

--- a/src/arch/kim-1/boot/build.py
+++ b/src/arch/kim-1/boot/build.py
@@ -14,7 +14,6 @@ def mkpap(self, name, src: Target = None):
         label="SREC",
     )
 
-
 llvmrawprogram(
     name="boot.bin",
     srcs=["./boot.S"],
@@ -47,6 +46,19 @@ llvmrawprogram(
     linkscript="./boot.ld",
 )
 
+llvmrawprogram(
+    name="bootsdshield.bin",
+    srcs=["./bootsdshield.S"],
+    linkscript="./boot.ld",
+)
+
+llvmrawprogram(
+    name="bootsdshield-kimrom.bin",
+    srcs=["./bootsdshield.S"],
+    cflags=["-DKIM_ROM"],
+    linkscript="./boot-kimrom.ld",
+)
+
 mkpap(name="boot.pap", src=".+boot.bin")
 
 mkpap(name="bootsd.pap", src=".+bootsd.bin")
@@ -54,3 +66,5 @@ mkpap(name="bootsd.pap", src=".+bootsd.bin")
 mkpap(name="bootiec-kim.pap", src=".+bootiec-kim.bin")
 
 mkpap(name="bootiec-pal.pap", src=".+bootiec-pal.bin")
+
+mkpap(name="bootsdshield.pap", src=".+bootsdshield.bin")

--- a/src/arch/kim-1/build.py
+++ b/src/arch/kim-1/build.py
@@ -73,6 +73,13 @@ llvmclibrary(
 )
 
 llvmclibrary(
+    name="sdshield",
+    srcs=["./sdshield.S", "./kim-1-sdshield.S"],
+    deps=["include"],
+    hdrs={"sdshield.inc": "./sdshield.inc", "parproto.inc": "./parproto.inc"},
+)
+
+llvmclibrary(
     name="iec-kim",
     srcs=["./kim-1-iec.S"],
     deps=["include"],
@@ -115,6 +122,13 @@ llvmrawprogram(
     linkscript="./kim-1-iec.ld",
 )
 
+llvmrawprogram(
+    name="bios-sdshield",
+    srcs=["./kim-1.S", "./kim-1.inc"],
+    deps=["include", "src/lib+bioslib", ".+pario", ".+sdshield"],
+    linkscript="./kim-1-sdcard.ld",
+)
+
 mkcpmfs(
     name="rawdiskimage-k1013",
     format="k-1013",
@@ -125,7 +139,7 @@ mkcpmfs(
         "0:scrvt100.com": "apps+scrvt100",
         "0:format.com": "src/arch/kim-1/utils+format",
         "0:format.txt": "src/arch/kim-1/cpmfs/format.txt",
-        "0:imu.com": "src/arch/kim-1/utils+imu",
+        "0:imu.com": "src/arch/kim-1/utils+imu_k1013",
         "0:imu.txt": "src/arch/kim-1/cpmfs/imu.txt",
         "0:sys.com": "apps+sys",
         "0:pasc.pas": "third_party/pascal-m+pasc_pas_cpm",
@@ -147,6 +161,28 @@ mkcpmfs(
     items={
         "0:ccp.sys@sr": "src+ccp", "0:bdos.sys@sr": "src/bdos",
         "0:scrvt100.com": "apps+scrvt100",
+        "0:pasc.pas": "third_party/pascal-m+pasc_pas_cpm",
+    }
+    | MINIMAL_APPS
+    | MINIMAL_APPS_SRCS
+    | BIG_APPS
+    | BIG_APPS_SRCS
+    | SCREEN_APPS
+    | BIG_SCREEN_APPS
+    | PASCAL_APPS,
+)
+
+mkcpmfs(
+    name="rawdiskimage-sdshield",
+    format="k-1013",
+    bootimage=".+bios-sdshield",
+    size=256 * 77 * 26,
+    items={
+        "0:ccp.sys@sr": "src+ccp", "0:bdos.sys@sr": "src/bdos",
+        "0:scrvt100.com": "apps+scrvt100",
+        "0:imu.com": "src/arch/kim-1/utils+imu_sdshield",
+        "0:imu.txt": "src/arch/kim-1/cpmfs/imu.txt",
+        "0:sys.com": "apps+sys",
         "0:pasc.pas": "third_party/pascal-m+pasc_pas_cpm",
     }
     | MINIMAL_APPS
@@ -214,5 +250,15 @@ zip(
         "bootiec-kim.pap": "src/arch/kim-1/boot+bootiec-kim.pap",
         "bootiec-pal.bin": "src/arch/kim-1/boot+bootiec-pal.bin",
         "bootiec-pal.pap": "src/arch/kim-1/boot+bootiec-pal.pap",
+    },
+)
+
+zip(
+    name="distro-sdshield",
+    items={
+        "CPM-BOOT.DSK": ".+rawdiskimage-sdshield",
+        "bootsdshield.bin": "src/arch/kim-1/boot+bootsdshield.bin",
+        "bootsdshield.pap": "src/arch/kim-1/boot+bootsdshield.pap",
+        "bootsdshield-kimrom.bin": "src/arch/kim-1/boot+bootsdshield-kimrom.bin",
     },
 )

--- a/src/arch/kim-1/kim-1-sdshield.S
+++ b/src/arch/kim-1/kim-1-sdshield.S
@@ -1,0 +1,263 @@
+; CP/M-65 Copyright © 2022 David Given
+; This file is licensed under the terms of the 2-clause BSD license. Please
+; see the COPYING file in the root project directory for the full text.
+
+; KIM-1 port Copyright © 2024 Eduardo Casino
+
+#include "zif.inc"
+#include "cpm65.inc"
+#include "sdshield.inc"
+
+.section loader, "ax"
+
+.global system_init
+zproc system_init, loader
+    ldy #0
+    sty selected_drive
+
+    dey
+    sty buffered_host_sector            ; Mark buffer data as invalid
+
+    ; Initialize Disk Parameter Block
+
+    lda #<DISK_BUFFER
+    sta zp_sds_buffer+0
+    lda #>DISK_BUFFER
+    sta zp_sds_buffer+1
+
+    lda #SECTORS_PER_TRACK
+    sta zp_sds_spt
+
+    ; Determine RAM size. Assumes at least a memory expansion from 0x2000 to 0x9fff
+
+    ldy #0
+    sty ptr+0
+    lda #0xa0
+    sta ptr+1
+
+    zloop
+        lda #0x55
+        sta (ptr), y
+        lda (ptr), y
+        cmp #0x55
+        bne 1f
+        lda #0xaa
+        sta (ptr), y
+        lda (ptr), y
+        cmp #0xaa
+        bne 1f
+        iny
+        zif_eq
+            inc ptr+1
+            lda ptr+1
+            cmp #0xff
+            beq 1f
+        zendif
+    zendloop
+1:  lda ptr+1
+    sta mem_end
+
+    rts
+
+.text
+
+; Select a disk.
+; A is the disk number.
+; Returns the DPH in XA.
+; Sets carry on error.
+
+zproc bios_SELDSK
+    cmp #(dphtab_end-dphtab)/2
+    zif_cs
+1:      sec                 ; invalid drive
+        rts
+    zendif
+
+    tay                     ; Save for later
+
+    ; Check that drive is mounted
+
+    jsr DiskStatus
+    and #1                  ; Mounted flag
+    beq 1b                  ; Not mounted
+
+    tya
+    sta selected_drive
+    asl a
+    tay
+    lda dphtab+0, y
+    ldx dphtab+1, y
+    clc
+    rts
+zendproc
+
+; Set the current absolute sector number.
+; XA is a pointer to a three-byte number.
+
+zproc bios_SETSEC
+    sta ptr+0
+    stx ptr+1
+
+    ; Copy bottom 16 of sector number to temporary (the top byte must be 0).
+
+    ldy #0
+    lda (ptr), y
+    sta ptr1+0
+    iny
+    lda (ptr), y
+    sta ptr1+1
+
+    ; There are 52 CP/M sectors per host track (each 256 byte host sector
+    ; contains two CP/M sects). Do a 16-bit divide.
+
+    ldx #16
+    lda #0
+    zrepeat
+        asl ptr1+0
+        rol ptr1+1
+        rol a
+        cmp #52
+        zif_cs
+            sbc #52
+            inc ptr1+0
+        zendif
+        dex
+    zuntil_eq
+
+    ; Host sectors are 256 bytes long, so divide by 2 and put carry as MSB of
+    ; buffer_offset
+    lsr a
+    sta requested_cpm_sector
+    lda #0
+    ror a
+    sta buffer_offset
+
+    lda ptr1+0
+    sta requested_track
+
+    clc
+    rts
+zendproc
+
+; --- Disk access -----------------------------------------------------------
+
+; This assumes that DISK_BUFFER is page aligned!!
+
+zproc set_disk_buffer_offset
+    ; WARNING: DISK_BUFFER __must__ be page aligned!!
+
+    lda buffer_offset
+    sta ptr+0
+    lda #>DISK_BUFFER
+    sta ptr+1
+
+    rts
+zendproc
+
+zproc change_sector
+    ; First check if requested sector is already in buffer
+
+    lda requested_cpm_sector
+    cmp buffered_host_sector
+    zif_eq
+        lda requested_track
+        cmp buffered_track
+        zif_eq
+            lda selected_drive
+            cmp buffered_drive
+            zif_eq
+                ; Buffered disk/track/sector not changing, so do no work.
+
+                clc
+                rts
+            zendif
+        zendif
+    zendif
+
+    ; If requested sector is not buffered, flush buffer before changing
+
+    bit buffer_dirty
+    zif_mi
+        jsr flush_buffer
+        zif_cs
+            rts
+        zendif
+    zendif
+
+    ; Change sector
+
+    lda selected_drive
+    sta buffered_drive
+    lda requested_track
+    sta buffered_track
+    lda requested_cpm_sector
+    sta buffered_host_sector
+
+    ; Read sector from disk
+
+    lda buffered_host_sector
+    sta zp_sds_sector
+    lda buffered_track
+    sta zp_sds_track
+    lda buffered_drive
+    sta zp_sds_drive
+
+    jsr DiskReadSector
+    zif_cc
+        rts
+    zendif
+
+    ; Some kind of read error. The data in the buffer is corrupt.
+
+    lda #0xff
+    sta buffered_host_sector
+
+    rts
+zendproc
+
+zproc flush_buffer
+    lda buffered_host_sector
+    sta zp_sds_sector
+    lda buffered_track
+    sta zp_sds_track
+    lda buffered_drive
+    sta zp_sds_drive
+
+    jsr DiskWriteSector
+    zif_cc
+        ; A successful write, so mark the buffer as clean.
+
+        lda #0
+        sta buffer_dirty
+        rts
+    zendif
+
+    sec
+    rts
+zendproc
+
+; --- Data ------------------------------------------------------------------
+
+.data 
+
+dphtab:
+    .word dph_floppyA
+    .word dph_floppyB
+    .word dph_floppyC
+    .word dph_floppyD
+dphtab_end:
+
+define_drive dph_floppyA, TRACKS*SECTORS_PER_TRACK*2, 2048, 128, SECTORS_PER_TRACK*2
+define_drive dph_floppyB, TRACKS*SECTORS_PER_TRACK*2, 2048, 128, SECTORS_PER_TRACK*2
+define_drive dph_floppyC, TRACKS*SECTORS_PER_TRACK*2, 2048, 128, SECTORS_PER_TRACK*2
+define_drive dph_floppyD, TRACKS*SECTORS_PER_TRACK*2, 2048, 128, SECTORS_PER_TRACK*2
+
+.bss
+
+selected_drive:          .fill 1     ; Current selected disk drive number
+buffer_offset:          .fill 1     ; Offset of CP/M sector into host sector buffer
+requested_cpm_sector:   .fill 1     ; CP/M sector requested by user
+requested_track:        .fill 1     ; track requested by user
+buffered_host_sector:   .fill 1     ; host sector in buffer
+buffered_track:         .fill 1     ; track in buffer
+buffered_drive:         .fill 1     ; Drive of track/sector in buffer

--- a/src/arch/kim-1/pario.S
+++ b/src/arch/kim-1/pario.S
@@ -1,0 +1,206 @@
+;*****************************************************
+; These are the low-level I/O routines to talk to the
+; Arduino processor connected to the KIM's I/O port.
+;
+; August 2014, Bob Applegate K2UT, bob@corshamtech.com
+;
+; Which port bits are used for what:
+;
+; A0 = Data 0, alternates input/output
+; A1 = Data 1, alternates input/output
+; A2 = Data 2, alternates input/output
+; A3 = Data 3, alternates input/output
+; A4 = Data 4, alternates input/output
+; A5 = Data 5, alternates input/output
+; A6 = Data 6, alternates input/output
+; A7 = Data 7, alternates input/output
+;
+; B0 = Direction bit, always output
+; B1 = Write strobe or ACK, always output
+; B2 = Read stroke or ACK, always input
+;
+
+#include "zif.inc"
+#include "kim-1.inc"
+
+;----------------------------------------------------
+; Bits in the B register
+;
+DIRECTION = %00000001
+PSTROBE   = %00000010
+ACK       = %00000100
+;
+;----------------------------------------------------
+; The KIM has a 6530 with the two I/O ports at $1700.
+;
+; Addresses of 6530 registers
+;
+PIABASE = PORTA
+PIAREGA = PIABASE       ;data reg A
+PIADDRA = PIABASE+1     ;data dir reg A
+PIAREGB = PIABASE+2     ;data reg B
+PIADDRB = PIABASE+3     ;data dir reg B
+
+;*****************************************************
+; This is the initialization function.  Call before
+; doing anything else with the parallel port.
+;
+zproc xParInit, .text.xParInit
+
+;
+; Set up the data direction register for port B so that
+; the DIRECTION and PSTROBE bits are output.  Only touch
+; the bits we're using; leave the rest as-is.
+;
+    lda PIADDRB        ;get current value
+    and #~ACK & $ff
+    ora #DIRECTION | PSTROBE
+    sta PIADDRB
+zendproc
+;
+; Fall through
+;
+;*****************************************************
+; This sets up for writing to the Arduino.  Sets up
+; direction registers, drives the direction bit, etc.
+;
+zproc xParSetWrite, .text.xParSetWrite
+    lda #$ff            ;set bits for output
+    sta PIADDRA
+;
+; Set direction flag to output, clear ACK bit
+;
+    lda PIAREGB
+    and #~(PSTROBE | ACK) & $ff
+    ora #DIRECTION
+    sta PIAREGB
+    rts
+zendproc
+
+
+;*****************************************************
+; This sets up for reading from the Arduino.  Sets up
+; direction registers, clears the direction bit, etc.
+;
+zproc xParSetRead, .text.xParSetRead
+    lda #$00            ;set bits for input
+    sta PIADDRA
+;
+; Set direction flag to input, clear ACK bit
+;
+    lda PIAREGB
+    and #~(DIRECTION | PSTROBE | ACK) & $ff
+    sta PIAREGB
+    rts
+zendproc
+
+        
+;*****************************************************
+; This writes a single byte to the Arduino.  On entry,
+; the byte to write is in A.  This assumes ParSetWrite
+; was already called.
+;
+; Destroys A, all other registers preserved.
+;
+; Write cycle:
+;
+;    1. Wait for other side to lower ACK.
+;    2. Put data onto the bus.
+;    3. Set DIRECTION and PSTROBE to indicate data
+;       is valid and ready to read.
+;    4. Wait for ACK line to go high, indicating the
+;       other side has read the data.
+;    5. Lower PSTROBE.
+;    6. Wait for ACK to go low, indicating end of
+;       transfer.
+;
+zproc xParWriteByte, .text.xParWriteByte
+    pha                 ;save data
+    zrepeat
+        lda PIAREGB     ;check status
+        and #ACK
+    zuntil_eq           ;wait for ACK to go low
+
+;
+; Now put the data onto the bus
+;
+    pla
+    sta PIAREGA
+;
+; Raise the strobe so the Arduino knows there is
+; new data.
+;
+    lda PIAREGB
+    ora #PSTROBE
+    sta PIAREGB
+;
+; Wait for ACK to go high, indicating the Arduino has
+; pulled the data and is ready for more.
+;
+    zrepeat
+        lda PIAREGB
+        and #ACK
+    zuntil_ne
+
+;
+; Now lower the strobe, then wait for the Arduino to
+; lower ACK.
+;
+    lda PIAREGB
+    and #~PSTROBE & $ff
+    sta PIAREGB
+    zrepeat
+        lda PIAREGB
+        and #ACK
+    zuntil_eq
+    rts
+zendproc
+
+
+;*****************************************************
+; This reads a byte from the Arduino and returns it in
+; A.  Assumes ParSetRead was called before.
+;
+; This does not have a time-out.
+;
+; Preserves all other registers.
+;
+; Read cycle:
+;
+;    1. Wait for other side to raise ACK, indicating
+;       data is ready.
+;    2. Read data.
+;    3. Raise PSTROBE indicating data was read.
+;    4. Wait for ACK to go low.
+;    5. Lower PSTROBE.
+;
+zproc xParReadByte, .text.xParReadByte
+    zrepeat
+        lda PIAREGB
+        and #ACK        ;is their strobe high?
+    zuntil_ne           ;nope, no data
+;
+; Data is available, so grab and save it.
+;
+    lda PIAREGA
+    pha
+;
+; Now raise our strobe (their ACK), then wait for
+; them to lower their strobe.
+;
+    lda PIAREGB
+    ora #PSTROBE
+    sta PIAREGB
+    zrepeat
+        lda PIAREGB
+        and #ACK
+    zuntil_eq           ;still active 
+;
+; Lower our ack, then we're done.
+;
+    lda PIAREGB
+    and #~PSTROBE & $ff
+    sta PIAREGB
+    pla
+    rts
+zendproc

--- a/src/arch/kim-1/parproto.inc
+++ b/src/arch/kim-1/parproto.inc
@@ -1,0 +1,78 @@
+;*****************************************************
+; Parallel port protocol
+;
+; This is the header file for making applications
+; compliant with The Remote Disk Protocol Guide which
+; is on the Corsham Technologies web page somewhere:
+;
+;    www.corshamtech.com
+;
+; This was updated 06/13/2015 to be compliant with the
+; official specification, so the opcode values changed.
+;
+; Another update on 02/10/2019
+;
+;=====================================================
+; Commands from host to Arduino
+;
+PC_GET_VERSION  = $01
+PC_PING         = $05       ;ping Arduino
+PC_LED_CONTROL  = $06       ;LED control
+PC_GET_CLOCK    = $07       ;get clock data
+PC_SET_CLOCK    = $08       ;set clock
+PC_GET_DIR      = $10       ;Get directory
+PC_GET_MOUNTED  = $11       ;Get mounted drive list
+PC_MOUNT        = $12       ;Mount drive
+PC_UNMOUNT      = $13       ;Unmount drive
+PC_GET_STATUS   = $14       ;Get status for one drive
+PC_DONE         = $15       ;Stop data
+PC_ABORT        = PC_DONE
+PC_READ_FILE    = $16       ;Read regular file (non-DSK)
+PC_READ_BYTES   = $17       ;Read s=ential bytes
+PC_RD_SECTOR    = $18       ;Read FLEX sector
+PC_WR_SECTOR    = $19       ;Write FLEX sector
+PC_GET_MAX      = $1a       ;Get maximum drives
+PC_WRITE_FILE   = $1b       ;Open file for writing
+PC_WRITE_BYTES  = $1c       ;Data to be written
+PC_SAVE_CONFIG  = $1d       ;Save SD.CFG with current values
+PC_SET_TIMER    = $1e       ;Set RTC timer
+PC_RD_SEC_LONG  = $1f       ;Read sector with long sec num
+PC_WR_SEC_LONG  = $20       ;Write sector with long sec num
+PC_FORMAT       = $21       ;Format (create) new image
+PC_ERASE        = $22       ;Delete file from SD       
+PC_RENAME       = $23       ;Rename file on SD
+PC_COPY         = $24       ;Copy file on SD
+;
+;=====================================================
+; Responses from Arduino to host
+;
+PR_VERSION_INFO = $81       ;Contains version information
+PR_ACK          = $82       ;ACK (no additional information)
+PR_NAK          = $83       ;NAK - one status byte follows
+PR_PONG         = $85       ;Reply to a ping
+PR_CLOCK_DATA   = $87       ;Clock data
+PR_DIR_ENTRY    = $90       ;Directory entry
+PR_DIR_END      = $91       ;End of directory entries
+PR_FILE_DATA    = $92       ;File data
+PR_STATUS       = $93       ;Drive status
+PR_SECTOR_DATA  = $94       ;Sector data
+PR_MOUNT_INFO   = $95       ;Mount entry
+PR_MAX_DRIVES   = $96       ;Maximum number of drives
+;
+;=====================================================
+; Error codes for NAK events
+;
+ERR_NONE             = 0
+ERR_FEATURE_DISABLED = 8
+ERR_FILE_EXISTS      = 9
+ERR_NOT_MOUNTED      = 10
+ERR_MOUNTED          = 11
+ERR_NOT_FOUND        = 12
+ERR_READ_ONLY        = 13
+ERR_BAD_DRIVE        = 14
+ERR_BAD_TRACK        = 15
+ERR_BAD_SECTOR       = 16
+ERR_READ_ERROR       = 17
+ERR_WRITE_ERROR      = 18
+ERR_NOT_PRESENT      = 19
+ERR_NOT_IMPL         = 20        ;Command not implemented

--- a/src/arch/kim-1/sdshield.S
+++ b/src/arch/kim-1/sdshield.S
@@ -1,0 +1,190 @@
+;=====================================================
+; This is a collection of functions for performing
+; higher level disk functions.  This hides the nasty
+; details of communications with the remote disk
+; system.
+;
+; August 20, 2014 - Bob Applegate
+;                   bob@corshamtech.com
+;
+; 06/14/2015 - Bob Applegate
+;       Now that there is an official standard
+;       for the protocol between the host (this
+;       code) and the DCP (Arduino code), this
+;       code has been updated to be compliant.
+;
+; 12/26/2024 - Eduardo Casino
+;       Adapted to the 6502
+;
+
+#include "zif.inc"
+#include "parproto.inc"
+
+.section .zp, "zax", @nobits
+
+.global zp_sds_dpb, zp_sds_drive, zp_sds_track, zp_sds_sector
+.global zp_sds_spt, zp_sds_buffer
+
+; Disk parameter block
+
+zp_sds_dpb:
+zp_sds_drive:           .fill 1
+zp_sds_track:           .fill 1
+zp_sds_sector:          .fill 1
+zp_sds_spt:             .fill 1     ; Sectors per track
+zp_sds_buffer:          .fill 2     ; Pointer to data buffer
+
+;=====================================================
+; This is a low level disk function for a real OS to
+; perform a disk sector read.  On entry, zp_sds_dpb
+; is a disk parameter block with the following fields:
+;
+;    drive             DS   1
+;    track             DS   1
+;    sector            DS   1
+;    sectors per track DS   1
+;    ptr to data       DS   2   must be 256 bytes long!
+;
+; The first three fields are zero based.  Sectors per
+; track is a one based value.
+;
+; Returns with C clear on success.  If error, C is set
+; and A contains the error code.
+;
+zproc DiskReadSector, .text.DiskReadSector
+    lda #PC_RD_SECTOR       ;sector read command
+    jsr Dsendinfo
+;
+; Now get the response.  Will be either a NAK followed
+; by an error code, or a 97 followed by 256 bytes of
+; data.
+;
+    jsr xParSetRead
+    jsr xParReadByte        ;response
+    cmp #PR_SECTOR_DATA     ;data?
+    bne DiskRetErrCode      ;no
+
+; Read 256 bytes to the address at zp_sd_address
+
+    ldy #0
+    zrepeat
+        jsr xParReadByte
+        sta (zp_sds_buffer),y
+        iny
+    zuntil_eq
+;
+; All done
+;
+zendproc
+; Fall through
+zproc DiskCsuccess, .text.DiskCsuccess
+    jsr xParSetWrite
+    clc
+    rts
+zendproc
+
+;=====================================================
+; This is a low level disk function for a real OS to
+; perform a disk sector write.  On entry, zp_sds_dpb is
+; a disk parameter block with the following fields:
+;
+;    drive             DS   1
+;    track             DS   1
+;    sector            DS   1
+;    sectors per track DS   1
+;    ptr to data       DS   2   must be 256 bytes long!
+;
+; The first three fields are zero based.  Sectors per
+; track is one based.
+;
+; Returns with C clear on success.  If error, C is set
+; and A contains the error code.
+;
+zproc DiskWriteSector, .text.DiskWriteSector
+    lda #PC_WR_SECTOR       ;write sector command
+    jsr Dsendinfo
+    ldy #0
+    zrepeat
+        lda (zp_sds_buffer),y
+        jsr xParWriteByte
+        iny
+    zuntil_eq
+;
+; Now get response.
+;
+    jsr xParSetRead
+    jsr xParReadByte
+    cmp #PR_NAK             ;NAK?
+    bne DiskCsuccess
+zendproc
+; Fall through
+zproc DiskRetErrCode, .text.DiskRetErrCode
+    ;
+    ; Assume it's a NAK.
+    ;
+    jsr xParReadByte        ;get error code
+    pha
+    jsr xParSetWrite
+    pla
+    sec
+    rts
+zendproc
+;
+;=====================================================
+; This is a helper function for the read and write
+; functions.  Enter with A containing the command to
+; be sent, X pointing to the data area.  This sends
+; the command, then the drive, track, sector and
+; sectors per track from the data area.
+;
+; This must not modify the FCB!  The caller might
+; depend on the values in it.
+;
+; This also de-Flexes the sector number.  Ie, any
+; track other than 0 and any sector on track zero
+; greater than one has one subtraced from it.
+;
+zproc Dsendinfo, .text.Dsendinfo
+    jsr xParWriteByte           ;command
+    lda zp_sds_drive            ;get drive
+    jsr xParWriteByte           ;drive
+    lda #2                      ;256 byte sectors
+    jsr xParWriteByte
+    lda zp_sds_track            ;get track
+    jsr xParWriteByte           ;track
+    lda zp_sds_sector           ;get sector
+    jsr xParWriteByte           ;sector
+    lda zp_sds_spt              ;get tracks/sector
+    jmp xParWriteByte
+zendproc
+
+;=====================================================
+; Gets status of a specific drive.  The drive number
+; (0-3) is in A on entry.
+;
+; Returns a bitmapped value in A:
+;
+;    P0000ERU
+;
+;  U: 0 = not present, 1 = Mounted
+;  R: 0 = Read only, 1 = Read/write
+;  E: 0 = no error, 1 = access error (bad sector?)
+;
+; The E bit will never be set for status.
+;
+zproc DiskStatus, .text.DiskStatus
+    pha
+    lda #PC_GET_STATUS      ;get status command
+    jsr xParWriteByte       ;send request for data
+    pla
+    jsr xParWriteByte
+    jsr xParSetRead
+    jsr xParReadByte        ;get result code (always PR_STATUS)
+    jsr xParReadByte        ;get status byte
+    pha
+    jsr xParSetWrite
+    pla
+    clc
+    rts
+zendproc
+

--- a/src/arch/kim-1/sdshield.inc
+++ b/src/arch/kim-1/sdshield.inc
@@ -1,0 +1,11 @@
+; CP/M-65 Copyright © 2022 David Given
+; This file is licensed under the terms of the 2-clause BSD license. Please
+; see the COPYING file in the root project directory for the full text.
+
+; KIM-1 port Copyright © 2024 Eduardo Casino
+
+; Emulate a SSDD drive
+
+#define TRACKS 77
+#define SECTORS_PER_TRACK 26
+#define SECTOR_SIZE 256

--- a/src/arch/kim-1/utils/build.py
+++ b/src/arch/kim-1/utils/build.py
@@ -1,4 +1,28 @@
-from build.llvm import llvmprogram
+from build.llvm import llvmprogram, llvmclibrary
+
+llvmclibrary(
+    name="imu-k1013",
+    srcs=["./imu-k1013.S"],
+    deps=["include"],
+    hdrs={"k-1013.inc": "src/arch/kim-1/k-1013.inc"},
+)
+
+llvmclibrary(
+    name="imu-sdshield",
+    srcs=["./imu-sdshield.S"],
+    deps=["include"],
+    hdrs={
+        "sdshield.inc": "src/arch/kim-1/sdshield.inc",
+        "parproto.inc": "src/arch/kim-1/parproto.inc",
+    },
+)
+
+llvmclibrary(
+    name="sdshield",
+    srcs=["./sdshield.S"],
+    deps=["include"],
+    hdrs={"parproto.inc": "src/arch/kim-1/parproto.inc"},
+)
 
 llvmprogram(
     name="format",
@@ -11,11 +35,26 @@ llvmprogram(
 )
 
 llvmprogram(
-    name="imu",
+    name="imu_k1013",
     srcs=["./imu.S"],
     cflags=["-I src/arch/kim-1"],
     deps=[
         "include",
         "src/arch/kim-1/k-1013.inc",
+        ".+imu-k1013",
+    ],
+)
+
+llvmprogram(
+    name="imu_sdshield",
+    srcs=["./imu.S"],
+    cflags=["-I src/arch/kim-1"],
+    deps=[
+        "include",
+        "src/arch/kim-1/parproto.inc",
+        "src/arch/kim-1/sdshield.inc",
+        ".+imu-sdshield",
+        ".+sdshield",
+        "src/arch/kim-1+pario",
     ],
 )

--- a/src/arch/kim-1/utils/imu-k1013.S
+++ b/src/arch/kim-1/utils/imu-k1013.S
@@ -1,0 +1,775 @@
+; ---------------------------------------------------------------------------
+;
+; Image Manipulation Utility
+;
+; Copyright (C) 2025 Eduardo Casino
+; This file is licensed under the terms of the 2-clause BSD license. Please
+; see the COPYING file in the root project directory for the full text.
+;
+; ---------------------------------------------------------------------------
+
+#include "zif.inc"
+#include "cpm65.inc"
+#include "k-1013.inc"
+
+DMA_BUFFER = $fd00          ; We are using the 256-byte page just below the disk
+DMA_AREA = $f4              ; buffer ($fd00), which encodes to $f4. See K-1013 manual.
+
+    .data
+
+; Initialized variables
+
+pk_flag:        .byte 0             ; Create packed image flag
+
+    .text
+
+zproc init
+
+    lda #<DMA_BUFFER
+    sta buffer1+0
+    lda #>DMA_BUFFER
+    sta buffer1+1
+
+    ; Put the disk controller in a sane state
+    ;
+    lda HSRC                        ; Test if an interrupt is pending
+    zif_pl
+        jsr fdc_exec_senseint
+    zendif
+
+    lda #0                          ; Set DMA read mode, unprotect SYSRAM
+    sta HSRC
+
+    ; Using a harmless command to check extended cmds support
+
+    ldy #EXT_CMD_DIR
+    jsr fdc_exec_extended           ; Get SD card directory listing
+    zif_cc
+        ; Dig further for errors
+        lda disk_status
+        zif_pl
+            clc
+            rts
+        zendif
+        lda #<real_msg              ; Extended commands not supported
+        ldx #>real_msg
+    zelse
+        lda #<fdc_msg               ; Controller error
+        ldx #>fdc_msg
+    zendif
+
+    jsr err_withmsg
+    sec
+    rts
+zendproc
+
+; Check if drive exists. Returns C if not.
+;
+zproc drive_exists
+    lda drive
+    cmp #4
+    zif_cs    
+        ldx drive_letter
+        lda #<invalid_msg
+        ldy #>invalid_msg
+        jsr err_withchar
+        sec
+    zendif
+    rts
+zendproc
+
+; Checks that the image name is valid
+; Y must point to the first character of the
+; image name in the command line
+; C set if invalid
+;
+; Just checks that length < 64 chars, excluding
+; terminating null. The firmware does proper
+; validation
+;
+zproc check_valid_file
+
+    ; Find end of file
+
+    dey
+    ldx #0xff
+    zrepeat
+        inx
+        iny
+        lda cpm_cmdline,y
+        zbreakif_mi                 ; Safeguard, stop if len > 128 chars
+    zuntil_eq
+
+    ; Check it is shorter that 64 chars, fail if not
+
+    cpx #64
+    zif_cs
+        lda #<imagerr_msg           ; Cant be past the 64th pos
+        ldx #>imagerr_msg
+        jsr err_withmsg
+        sec
+    zendif
+    rts
+zendproc
+
+; Produces a list on screen of available images
+; 
+zproc list_mounts
+
+    ldy #EXT_CMD_MNTS
+    jsr fdc_exec_extended           ; Get SD card directory listing
+    zif_cs
+        lda #<fdc_msg
+        ldx #>fdc_msg
+        jmp err_withmsg             ; Controller error
+    zendif
+    
+    ; Set buffer for receiving file names
+
+    lda #DMA_AREA
+    sta ADMA
+
+    zloop
+        ldy #EXT_CMD_NXT_MNT
+        jsr fdc_exec_extended       ; Get SD card directory entry
+        zif_cs
+            lda #<fdc_msg
+            ldx #>fdc_msg
+            jmp err_withmsg         ; Controller error
+        zendif       
+
+        ; Check status for errors
+
+        lda disk_status
+        and #ST4_NO_DATA
+        zbreakif_ne
+
+        jsr print_mount
+
+    zendloop
+    rts
+zendproc
+
+; Produces a list on screen of available images
+; 
+zproc list_images
+
+    ; Set buffer for receiving file names
+
+    lda #DMA_AREA
+    sta ADMA
+
+    zloop
+        ldy #EXT_CMD_NXT
+        jsr fdc_exec_extended       ; Get SD card directory entry
+        zif_cs
+            lda #<fdc_msg
+            ldx #>fdc_msg
+            jmp err_withmsg         ; Controller error
+        zendif       
+
+        ; No need to check for extended command support
+
+        ; Check status for errors
+
+        lda #ST4_NO_DATA
+        bit disk_status
+        ; Testing for ST4_NO_DATA
+        zbreakif_ne
+        ; Testing for ST4_ABNORMAL_TERM (0b0100000)
+        zif_vs
+            lda #<readdir_msg
+            ldx #>readdir_msg
+            jmp err_withmsg         ; Error reading directory
+        zendif
+
+        lda #<DMA_BUFFER            ; Print it
+        ldx #>DMA_BUFFER
+        ldy #BDOS_WRITE_STRING
+        jsr BDOS
+        jsr pr_crlf
+    zendloop
+    rts
+zendproc
+
+; Mount an SD image to a CPM drive
+;
+zproc mount_image
+
+    lda #$01                        ; Set DMA direction bit to write
+    sta HSRC          
+
+    ; Set buffer for sending mount info
+
+    lda #DMA_AREA
+    sta ADMA
+
+    lda ro_flag
+    sta DMA_BUFFER+1
+    lda drive
+    sta DMA_BUFFER+0
+    ora #EXT_CMD_MNT
+    tay
+    jsr fdc_exec_extended           ; Mount image
+    zif_cs
+        lda #<fdc_msg
+        ldx #>fdc_msg
+        jmp err_withmsg             ; Controller error
+    zendif
+    
+    ; Dig further for errors
+
+    lda #ST4_NOT_FOUND
+    bit disk_status
+    ; Testing for ST4_NOT_FOUND
+    zif_ne
+        lda filename1+0
+        ldx filename1+1
+        jmp err_notfound
+    zendif
+    zif_vs
+        lda disk_status+1
+        and #ST5_DRV_MOUNTED
+        zif_ne
+            ; Was not mounted
+            ldx drive_letter
+            lda #<mountederr_msg
+            ldy #>mountederr_msg
+            jmp err_withchar
+        zendif
+        lda disk_status+1
+        and #ST5_IMG_MOUNTED
+        zif_ne
+            ; Was not mounted
+            lda filename1+0
+            ldx filename1+1
+            jmp err_imgmounted
+        zendif
+        lda disk_status+1
+        and #ST5_IMG_INVALID
+        zif_ne
+            ; It is not a valid IMD file
+            lda filename1+0
+            ldx filename1+1
+            jmp err_invalidimg
+        zendif
+        ; If we are here, there was an unexpected error
+
+        ldx drive_letter
+        lda #<mounterr_msg
+        ldy #>mounterr_msg
+        jmp err_withchar
+    zendif
+
+    jmp print_mount                 ; Print the mount info
+
+zendproc
+
+; Unmount a drive.
+;
+zproc unmount_drive
+
+    jsr get_drive
+    zif_cs
+        jmp err_usage
+    zendif
+
+    jsr drive_exists
+    zif_cs
+        rts
+    zendif
+
+    lda drive
+    ora #EXT_CMD_UMNT               ; Unmount drive
+    tay
+    jsr fdc_exec_extended 
+    zif_cs
+        lda #<fdc_msg
+        ldx #>fdc_msg
+        jmp err_withmsg             ; Controller error
+    zendif
+    
+    ; Dig further for errors
+
+    and #ST4_ABNORMAL_TERM
+    zif_ne
+        lda disk_status+1
+        and #ST5_DRV_NOT_MOUNTED
+        zif_ne
+            ; Was not mounted
+            ldx drive_letter
+            lda #<notmntederr_msg
+            ldy #>notmntederr_msg
+            jmp err_withchar
+        zendif
+
+        ; If we are here, there was an unexpected error
+
+        ldx drive_letter
+        lda #<unmnterr_msg
+        ldy #>unmnterr_msg
+        jmp err_withchar
+    zendif
+
+    jmp inf_done
+zendproc
+
+; Update config to flash. Not yet supported
+;
+zproc save_config
+    lda #<unknown_msg
+    ldy #>unknown_msg
+    jsr err_withchar
+    jmp err_usage
+zendproc
+
+; Create an empty image on the SD card.
+;
+zproc create_image
+
+    jsr validate_image_name
+    zif_cs
+        rts
+    zendif
+    
+    ; Set filename1
+    ;
+    ; NOTE: We can do this because DMA_BUFFER is page aligned!
+    ;
+    ldy #4                          ; Skip image parameters
+    lda #>DMA_BUFFER
+    sty filename1+0
+    sta filename1+1
+
+    jsr set_image_name              ; Copy image name at DMA_BUFFER,Y
+                                    ; On exit, Y points to the next char after
+                                    ; image name in command line
+    jsr skip_sp
+ 
+    cmp #0                          ; End of command line?
+    zif_ne
+        jsr get_option              ; No, get option
+        zif_cs
+            jmp err_usage           ; Syntax error
+        zendif
+        cpx #'P'                    ; Create packaged image
+        zif_eq
+            ldx #PACKAGED_IMG
+            stx pk_flag
+        zelse
+            lda #<unknown_msg
+            ldy #>unknown_msg
+            jsr err_withchar        ; No other switches are supported
+            jmp err_usage
+        zendif
+    zendif    
+
+    jsr skip_sp
+
+    cmp #0
+    zif_ne
+        jmp err_usage               ; Nothing else expected
+    zendif
+
+    lda #$01                        ; Set DMA direction bit to write
+    sta HSRC          
+
+    ; Set buffer for sending mount info
+
+    lda #BUFFER_DMA
+    sta ADMA
+
+    ; Prepare the command data
+
+    lda #77                         ; Tracks
+    sta DMA_BUFFER+0
+    lda #26                         ; Sectors
+    sta DMA_BUFFER+1
+    lda #1                          ; Sector size ( 1 == 256bytes )
+    ora pk_flag                     ; Whether or not is a packaged image
+    sta DMA_BUFFER+2
+    lda #0xe5                       ; Filler byte
+    sta DMA_BUFFER+3
+    ldy #EXT_CMD_NEW                ; Create image
+    jsr fdc_exec_extended
+    zif_cs
+        lda #<fdc_msg
+        ldx #>fdc_msg
+        jmp err_withmsg             ; Controller error
+    zendif
+    
+    ; Dig further for errors
+
+    lda disk_status
+    and #ST4_ABNORMAL_TERM
+    zif_ne
+        lda #ST5_IMG_NAME
+        bit disk_status+1
+        ; Testing for ST5_IMG_NAME
+        zif_ne
+            lda #<imagerr_msg
+            ldx #>imagerr_msg
+            jmp err_withmsg
+        zendif
+        ; Testing for ST5_DISK_FULL (0b10000000)
+        zif_mi
+            lda #<diskfull_msg
+            ldx #>diskfull_msg
+            jmp err_withmsg
+        zendif
+        ; Testing for ST5_IMG_EXISTS ( 0b0100000)
+        zif_vs
+            lda #<exists_msg
+            ldx #>exists_msg
+            jmp err_withmsg
+        zendif
+        ; If we are here, there was an unexpected error
+        lda #<generic_msg
+        ldy #>generic_msg
+        jmp err_withmsg
+    zendif
+
+    jmp inf_done
+zendproc
+
+; Delete file on the SD card
+;
+zproc delete_file
+    jsr set_first_image_name
+    zif_cs
+        rts
+    zendif
+
+    cmp #0
+    zif_ne
+        jmp err_usage               ; Nothing else expected
+    zendif
+
+    lda #$01                        ; Set DMA direction bit to write
+    sta HSRC          
+
+    ; Set buffer for sending mount info
+
+    lda #DMA_AREA
+    sta ADMA
+
+    ; Prepare the command data
+
+    ldy #EXT_CMD_ERA                ; Delete image
+    jsr fdc_exec_extended
+    zif_cs
+        lda #<fdc_msg
+        ldx #>fdc_msg
+        jmp err_withmsg             ; Controller error
+    zendif
+    
+    ; Dig further for errors
+
+    lda #ST4_NOT_FOUND
+    bit disk_status
+    ; Testing for ST4_NOT_FOUND
+    zif_ne
+        lda filename1+0
+        ldx filename1+1
+        jmp err_notfound
+    zendif
+    ; Testing for ST4_ABNORMAL_TERM (0b01000000)
+    zif_vs
+        lda disk_status+1
+        and #ST5_IMG_NAME
+        zif_ne
+            ; Invalid image name
+            lda #<imagerr_msg
+            ldx #>imagerr_msg
+            jmp err_withmsg
+        zendif
+        lda disk_status+1
+        and #ST5_IMG_MOUNTED
+        zif_ne
+            ; Was not mounted
+            lda filename1+0
+            ldx filename1+1
+            jmp err_imgmounted
+        zendif
+        ; If we are here, there was an unexpected error
+        lda #<generic_msg
+        ldy #>generic_msg
+        jmp err_withmsg
+    zendif
+
+    jmp inf_done
+zendproc
+
+; Copy or rename src file to dst file on the SD card
+;
+zproc copy_or_move_file
+    jsr set_first_image_name
+    zif_cs
+        rts
+    zendif
+
+    ; Set second file name into buffer
+
+    jsr set_second_image_name
+    zif_cs
+        rts
+    zendif
+
+    cmp #0
+    zif_ne
+        jmp err_usage               ; Nothing else expected
+    zendif
+
+    lda #$01                        ; Set DMA direction bit to write
+    sta HSRC          
+
+    ; Set buffer for sending mount info
+
+    lda #DMA_AREA
+    sta ADMA
+
+    ; Prepare the command data
+
+    lda rn_flag
+    zif_ne
+        ldy #EXT_CMD_MOV            ; Move/rename image
+    zelse
+        ldy #EXT_CMD_CPY            ; Copy image
+    zendif
+
+    jsr fdc_exec_extended
+    zif_cs
+        lda #<fdc_msg
+        ldx #>fdc_msg
+        jmp err_withmsg             ; Controller error
+    zendif
+    
+    ; Dig further for errors
+
+    lda #ST4_NOT_FOUND
+    bit disk_status
+    ; Testing for ST4_NOT_FOUND
+    zif_ne
+        lda filename1+0
+        ldx filename1+1
+        jmp err_notfound
+    zendif
+    ; Testing for ST4_ABNORMAL_TERM (0b01000000)
+    zif_vs
+        lda #ST5_IMG_NAME
+        bit disk_status+1
+        ; Testing for ST5_IMG_NAME
+        zif_ne
+            lda #<imagerr_msg
+            ldx #>imagerr_msg
+            jmp err_withmsg
+        zendif
+        ; Testing for ST5_DISK_FULL (0b10000000)
+        zif_mi
+            lda #<diskfull_msg
+            ldx #>diskfull_msg
+            jmp err_withmsg
+        zendif
+        ; Testing for ST5_IMG_EXISTS ( 0b0100000)
+        zif_vs
+            lda #<exists_msg
+            ldx #>exists_msg
+            jmp err_withmsg
+        zendif
+        lda disk_status+1
+        and #ST5_IMG_MOUNTED
+        zif_ne
+            ; Was not mounted
+            lda filename1+0
+            ldx filename1+1
+            jmp err_imgmounted
+        zendif
+        lda disk_status+1
+        and #ST5_IMG2_MOUNTED
+        zif_ne
+            ; Was not mounted
+            lda filename2+0
+            ldx filename2+1
+            jmp err_imgmounted
+        zendif
+        ; If we are here, there was an unexpected error
+        lda #<generic_msg
+        ldy #>generic_msg
+        jmp err_withmsg
+    zendif
+
+    jmp inf_done
+zendproc
+
+; Execute extended command
+; Command number in Y
+
+zproc fdc_exec_extended
+
+    sty fdc_extended+2              ; Set command number 
+
+    ldx #fdc_extended-fdc_commands  ; Command index into X
+    jsr fdc_exec_command
+    zif_cc
+        zrepeat
+            lda HSRC                ; Wait for interrupt
+        zuntil_pl
+    zendif
+    ; Read results into memory even if it failed (should be
+    ; unsupported command)
+    ;
+    jsr fdc_read_result
+    rts
+zendproc
+
+zproc fdc_exec_senseint
+    ; Wait until FDC interrupt
+
+    zrepeat
+        lda HSRC
+    zuntil_pl
+
+    ; Execute Sense Interrupt command
+
+    ldx #fdc_senseint-fdc_commands
+    jsr fdc_exec_command
+    zif_cc
+        ; Read results into memory
+
+        jsr fdc_read_result
+        zif_cc
+
+            ; Look for error in the status registers
+
+            lda disk_status         ; Check ST0
+            and #0xf8               ; Delete don't care bits
+            cmp #0x20               ; Result must be "Seek Completed"
+            bne fdc_fail
+            clc
+        zendif
+    zendif
+    rts
+zendproc
+
+zproc fdc_fail
+    sec
+    rts
+zendproc
+
+zproc fdc_exec_command
+
+    lda MSTR                        ; Load Main Status Register
+    and #0x10                       ; Check if busy
+    bne fdc_fail
+
+    ldy fdc_commands, x             ; Load command length
+    inx
+
+    zloop
+        zrepeat
+            lda MSTR                ; Wait until RQM from controller
+        zuntil_mi
+        and #0x40                   ; Test data direction bit
+        bne fdc_fail                ; Error if controller wants to talk
+
+        lda fdc_commands, x         ; Get command byte
+        sta DATR                    ; Store into FDC data register
+        inx                         ; Next command byte
+        dey
+    zuntil_eq
+
+    clc
+    rts
+zendproc
+
+zproc fdc_read_result
+    ldx #0
+    zloop
+        zrepeat
+            lda MSTR                ; Wait until RQM from controller
+        zuntil_mi
+        and #0x40                   ; Test data direction bit
+        beq fdc_fail                ; Error if controller wants to listen
+
+        lda DATR                    ; Get status byte from data register
+        sta disk_status, x          ; Put it into memory
+        inx                         ; Next byte
+        nop                         ; Give the controller time to update
+        nop                         ; the MSTR with a valid busy status
+        lda #0x10                   ; Check if busy and go get another
+        and MSTR                    ; byte while so
+    zuntil_eq
+
+    clc
+    rts
+zendproc
+
+; Error/Info message routines
+;
+zproc err_invalidimg
+    sta string+0
+    stx string+1
+    lda #<invalidimg_msg
+    ldx #>invalidimg_msg
+    jsr pr_str
+    lda string+0
+    ldx string+1
+    jsr pr_str
+    lda #<invalidimg_msg2
+    ldx #>invalidimg_msg2
+    jmp pr_str
+zendproc
+
+    .data
+
+; FDC extended command
+
+fdc_commands:
+
+fdc_senseint:
+    .byte 1                         ; Command length
+    .byte 8                         ; Sense Interrupt Status
+
+fdc_extended:
+    .byte 2                         ; Command length
+    .byte 0x1f                      ; Extended command
+    .byte 0                         ; Command number
+
+disk_status:    .fill 8             ; Result phase readouts from NEC-765
+
+; Messages
+
+    .global usage_msg
+
+usage_msg:      .ascii "Usage: imu [/L]\r\n"
+                .ascii "       imu /M <drive> [/O]\r\n"
+                .ascii "       imu /U <drive>\r\n"
+                .ascii "       imu /N <image> [/P]\r\n"
+                .ascii "       imu /D <image>\r\n"
+                .ascii "       imu {/C | /R} <src image> <dst image>\r\n\r\n"
+                .byte 0
+
+fdc_msg:        .ascii "Unexpected floppy controller failure.\r\n"
+                .byte 0
+
+real_msg:       .ascii "Not supported. Old firmware or real hardware.\r\n"
+                .byte 0
+
+diskfull_msg:   .ascii "SD card is full!\r\n"
+                .byte 0
+
+imagerr_msg:    .ascii "Image name invalid or longer than 63 chars.\r\n"
+                .byte 0
+
+open_msg:       .ascii "Failed to open directory.\r\n"
+                .byte 0
+
+readdir_msg:    .ascii "Failed to read directory.\r\n"
+                .byte 0
+
+invalidimg_msg: .ascii "Error: File '"
+                .byte 0
+invalidimg_msg2:.ascii "' is not a valid IMD image.\r\n"
+                .byte 0
+
+

--- a/src/arch/kim-1/utils/imu-sdshield.S
+++ b/src/arch/kim-1/utils/imu-sdshield.S
@@ -1,0 +1,616 @@
+; ---------------------------------------------------------------------------
+;
+; Image Manipulation Utility
+;
+; Copyright (C) 2025 Eduardo Casino
+; This file is licensed under the terms of the 2-clause BSD license. Please
+; see the COPYING file in the root project directory for the full text.
+;
+; ---------------------------------------------------------------------------
+
+#include "zif.inc"
+#include "cpm65.inc"
+#include "parproto.inc"
+#include "sdshield.inc"
+
+ZEROPAGE
+
+buffer2:        .fill 2             ; Read/Write buffer for disk operations
+
+    .bss
+
+; Uninitialized program variables
+
+version:        .fill 1             ; SD Shield protocol version
+
+    .text
+
+
+zproc init
+
+    ; Check the firmware version to make sure which features
+    ; are supported. Note: Version info in firmware <=1.4
+    ; is broken. Also, calling unsupported commands generate
+    ; a deadlock, so we are relying here in an undocumented
+    ; feature to retrieve the protocol version. This will
+    ; be 1 for firmware <=1.X and 2 or greater for >=2.0
+
+    ; Get the first free full page in memory and set buffer1
+    ; and buffer2
+
+    ldy #>cpm_ram
+    ldx #<cpm_ram
+    beq 1f
+    ldx #0
+    iny
+1:  stx buffer1+0
+    stx buffer2+0
+    sty buffer1+1
+    iny
+    sty buffer2+1
+
+    jsr GetProtoVersion
+    sta version
+    clc
+    rts
+zendproc
+
+; Check if drive exists. Returns C if not.
+;
+zproc drive_exists
+    lda #PC_GET_MAX
+    jsr DiskGetDrives
+    
+    cmp drive
+    zif_cs
+        zif_ne
+            clc
+            rts
+        zendif
+    zendif
+    ldx drive_letter
+    lda #<invalid_msg
+    ldy #>invalid_msg
+    jsr err_withchar
+    sec
+    rts
+zendproc
+
+; Checks that the image name is valid
+; Y must point to the first character of the
+; image name in the command line
+; C set if invalid
+;
+; Checks that it is an 8.3 file.
+;
+zproc check_valid_file
+
+    ; Find the dot (or blank or end of file)
+
+    dey
+    ldx #0xff
+    zrepeat
+        inx
+        iny
+        lda cpm_cmdline,y    
+        zbreakif_eq
+        cmp #'.'
+        zbreakif_eq
+        cmp #' '
+    zuntil_eq
+
+    ; Check it is between positions 1 and 8, fail if not
+
+    cpx #1
+    bcc 1f                          ; Cant be at the beginning
+    cpx #9
+    bcs 1f                          ; Cant be past the 9th pos
+
+    ; End of file?
+
+    cmp #'.'
+    zif_ne
+        clc
+        rts
+    zendif
+
+    ; Check the extension length
+
+    ldx #0xff
+    zrepeat
+        inx
+        iny
+        lda cpm_cmdline,y
+        zbreakif_eq
+        cmp #' '
+    zuntil_eq
+    cpx #4
+    bcc 2f                          ; Can't be greater than 3
+1:  lda #<imagerr_msg
+    ldx #>imagerr_msg
+    jsr err_withmsg
+    sec
+2:  rts
+zendproc
+
+; Produces a list on screen of drive mounts
+;
+zproc list_mounts
+    jsr DiskGetMounted              ; Get mounted drives
+    jsr set_buffer                  ; Output to buffer1
+    zloop
+        jsr DiskNextMountedDrv      ; Get entry
+        zbreakif_cs                 ; No more
+        jsr print_mount             ; Print it
+    zendloop
+    rts
+zendproc
+
+; Produces a list on screen of available images
+; 
+zproc list_images
+    jsr DiskDir                     ; Get SD card directory listing
+    zloop
+        jsr set_buffer              ; Output to buffer1
+        jsr DiskDirNext             ; Get entry
+        zbreakif_cs                 ; No more
+        lda buffer1+0               ; Print it
+        ldx buffer1+1
+        ldy #BDOS_WRITE_STRING
+        jsr BDOS
+        jsr pr_crlf
+    zendloop
+    rts
+zendproc
+
+; Sets the buffer for sending/receiving data
+;
+zproc set_buffer
+    lda buffer1+0
+    sta zp_sds_buffer
+    lda buffer1+1
+    sta zp_sds_buffer+1
+    rts
+zendproc
+
+; Sets second buffer for receiving data at the second page
+; of the free ram
+;
+zproc set_buffer_two
+    lda buffer2+0
+    sta zp_sds_buffer+0
+    ldy buffer2+1
+    sty zp_sds_buffer+1
+    rts
+zendproc
+
+; Mount an SD image to a CPM drive
+;
+zproc mount_image
+
+    ; Check if drive is already mounted
+
+    lda drive
+    jsr DiskStatus
+    and #1                          ; Mounted flag
+    zif_ne
+        ; Drive is mounted
+        ldx drive_letter
+        lda #<mountederr_msg
+        ldy #>mountederr_msg
+        jmp err_withchar
+    zendif
+
+    ; Prepare the mount info block for printing the mount and
+    ; load X and A for calling DiskMount
+    ;
+    ;    drive     BYTE        ; Base 0
+    ;    ro_flag   BYTE        ; Non-zero if RO
+    ;    name      STRING      ; Null-terminated Image name
+
+    lda #2                          ; We can do this because buffer1
+    sta zp_sds_buffer+0             ; is page aligned
+    lda buffer1+1
+    sta zp_sds_buffer+1
+    ldy #1
+    lda ro_flag
+    sta (buffer1),y
+    tax
+    dey
+    lda drive
+    sta (buffer1),y
+
+    jsr DiskMount                   ; Mount image
+
+    zif_cc
+        ; All went well
+        jmp print_mount             ; Print the mount info
+    zendif
+
+    ; If we are here, there was an error
+
+    cmp #ERR_NOT_FOUND              ; Image not found?
+    zif_ne
+        ; No, print generic mount error and exit
+        ldx drive_letter
+        lda #<mounterr_msg
+        ldy #>mounterr_msg
+        jmp err_withchar
+    zendif
+
+    lda filename1+0
+    ldx filename1+1
+    jmp err_notfound                ; Yes, print not found error and exit
+zendproc
+
+; Unmount a drive.
+;
+zproc unmount_drive
+    
+    jsr get_drive
+    zif_cs
+        jmp err_usage
+    zendif
+
+    jsr drive_exists
+    zif_cs
+        rts
+    zendif
+
+    ; Check if drive is already unmounted
+
+    lda drive
+    jsr DiskStatus
+    and #1                          ; Mounted flag
+    zif_eq
+        ; Was not mounted
+        ldx drive_letter
+        lda #<notmntederr_msg
+        ldy #>notmntederr_msg
+        jmp err_withchar
+    zendif
+
+    lda drive
+    jsr DiskUnmount
+    zif_cs
+        ; There was an unexpected error
+        ldx drive_letter
+        lda #<unmnterr_msg
+        ldy #>unmnterr_msg
+        jmp err_withchar
+    zendif
+    jmp inf_done
+zendproc
+
+; Update the SD config file with the latest mounted drives
+; situation. Issues warning if the file could not be
+; updated.
+;
+; Only for firmware >=2.0, as save config is broken in 1.X
+;
+zproc save_config
+    lda #1
+    cmp version
+    zif_cs
+        jsr err_firmware            ; Protocol < 2
+        sec
+    zendif
+
+    jsr inf_working                 ; It is a slow operation
+
+    jsr SaveConfig
+    zif_cs
+        lda #<config_msg
+        ldx #>config_msg
+        jmp err_withmsg
+    zendif
+    jsr inf_done
+    rts
+zendproc
+
+; Check if an image is mounted.
+;
+; On entry, XA is pointer to image name to check
+;
+; On exit, mn_flag != 0 if mounted.
+;
+zproc is_image_mounted
+    sta string+0
+    stx string+1
+
+    lda #0
+    sta mn_flag
+
+    jsr DiskGetMounted              ; Get mounted drives
+    jsr set_buffer_two              ; Output to buffer2
+    zloop
+        jsr DiskNextMountedDrv      ; Get entry
+        zbreakif_cs                 ; No more
+        ldy #0
+        zrepeat
+            lda (string),y
+            iny
+            iny
+            cmp (buffer2),y         ; If different, go check next file
+            zbreakif_ne
+            cmp #0                  ; Equal. End of file name?
+            zif_eq
+                inc mn_flag
+            zendif
+            dey
+            cmp #0                  ; Check if end of file name again
+        zuntil_eq
+    zendloop
+    rts
+zendproc
+
+; Common preamble of file manipulation functions
+; Returns Carry set on error
+;
+zproc file_common
+
+    ; Check the firmware version to make sure
+    ; it is supported.
+
+    lda #1
+    cmp version
+    zif_cs
+        jsr err_firmware            ; Protocol < 2
+        sec
+        rts
+    zendif
+
+    ; Check if there is an image name
+
+    jmp set_first_image_name
+
+zendproc
+
+; Create an empty image on the SD card.
+;
+zproc create_image
+
+    jsr file_common
+    zif_cs
+        rts
+    zendif
+
+    ldy cmdline_index
+    lda cpm_cmdline,y
+    zif_ne
+        jmp err_usage               ; No more parameters expected
+    zendif
+
+    jsr inf_working                 ; It is a slow operation
+
+    ; Prepare the disk parameter block for format. Beware the fields
+    ; in this file parameter block have different meaning for this
+    ; command!
+
+    lda #TRACKS
+    sta zp_sds_track
+    lda #SECTORS_PER_TRACK
+    sta zp_sds_sector
+    lda #0xe5
+    sta zp_sds_spt 
+    jsr set_buffer                  ; Set buffer for image name at buffer1
+
+    jsr DiskFormat                  ; Create image
+
+    zif_cs
+        cmp #ERR_FILE_EXISTS
+        zif_eq
+            lda #<exists_msg
+            ldx #>exists_msg
+            jmp err_withmsg
+        zendif
+
+        ; Anything else, generic error
+
+        lda #<generic_msg
+        ldx #>generic_msg
+        jmp err_withmsg
+    zendif
+    
+    jsr inf_done
+
+    rts
+zendproc
+
+; Delete file on the SD card
+;
+zproc delete_file
+
+    jsr file_common
+    zif_cs
+        rts
+    zendif
+
+    ldy cmdline_index
+    lda cpm_cmdline,y
+    zif_ne
+        jmp err_usage               ; No more parameters expected
+    zendif
+
+    lda filename1+0
+    ldx filename1+1
+    jsr is_image_mounted            ; Check if file is a mounted image
+    lda mn_flag
+    zif_ne
+        lda filename1+0
+        ldx filename1+1
+        jmp err_imgmounted
+    zendif
+
+    ; Warn user and get confirmation
+
+    lda filename1+0
+    ldx filename1+1
+    jsr wrn_delete
+    ldy #BDOS_CONSOLE_INPUT
+    jsr BDOS
+    cmp #'y'
+    zif_ne
+        jmp inf_usrabort
+    zendif
+    jsr pr_crlf
+
+    jsr set_buffer                  ; Set buffer for image name at buffer1
+    jsr DiskErase                   ; Delete file
+
+    zif_cs
+        cmp #ERR_FEATURE_DISABLED   ; Disabled by hardware switch?
+        zif_eq
+            lda #<disabled_msg
+            ldx #>disabled_msg
+            jmp err_withmsg
+        zendif
+        cmp #ERR_NOT_FOUND
+        zif_eq
+            lda filename1+0
+            ldx filename1+1
+            jmp err_notfound
+        zendif
+
+        ; Anything else, generic error msg
+
+        lda #<generic_msg
+        ldx #>generic_msg
+        jmp err_withmsg
+    zendif
+    jsr inf_done
+    rts
+zendproc
+
+; Copy or rename src file to dst file on the SD card
+;
+zproc copy_or_move_file
+
+    jsr file_common 
+    zif_cs
+        rts
+    zendif
+
+    ; Set second file name into buffer
+
+    jsr set_second_image_name
+    zif_cs
+        rts
+    zendif
+
+    ldy cmdline_index
+    lda cpm_cmdline,y
+    zif_ne
+        jmp err_usage               ; Should be 0 (no more parameters)
+    zendif
+
+    ; Check if destination is a mounted image
+
+    lda filename2+0
+    ldx filename2+1
+    jsr is_image_mounted
+    lda mn_flag
+    zif_ne
+        lda filename2+0
+        ldx filename2+1
+        jmp err_imgmounted
+    zendif
+
+    lda rn_flag
+    zif_eq
+        jsr inf_working             ; It is a slow operation
+        jsr set_buffer              ; Set buffer for image name at buffer1
+        jsr DiskCopy                ; Copy file
+    zelse
+        ; Check if origin is a mounted drive
+        lda filename1+0
+        ldx filename1+1
+        jsr is_image_mounted        ; Check if file is a mounted image
+        lda mn_flag
+        zif_ne
+            lda filename1+0
+            ldx filename1+1
+            jmp err_imgmounted
+        zendif
+        jsr inf_working             ; It is a slow operation
+        jsr set_buffer              ; Set buffer for image name at buffer1
+        jsr DiskRename              ; Move/rename
+    zendif
+
+    zif_cs
+        cmp #ERR_FEATURE_DISABLED   ; Disabled by hardware switch?
+        zif_eq
+            lda #<disabled_msg
+            ldx #>disabled_msg
+            jmp err_withmsg
+        zendif
+        cmp #ERR_NOT_FOUND
+        zif_eq
+            lda filename1+0
+            ldx filename1+1
+            jmp err_notfound
+        zendif
+        cmp #ERR_FILE_EXISTS
+        zif_eq
+            lda #<exists_msg
+            ldx #>exists_msg
+            jmp err_withmsg
+        zendif
+
+        ; Anything else, generic error msg
+
+        lda #<generic_msg
+        ldx #>generic_msg
+        jmp err_withmsg
+    zendif
+
+    jsr inf_done
+
+    rts
+zendproc
+
+; Error/Info message routines
+;
+zproc err_firmware
+    stx firmware_opt
+    lda #<firmware_msg
+    ldx #>firmware_msg
+    jmp pr_str
+zendproc
+
+zproc inf_working
+    lda #<working_msg
+    ldx #>working_msg
+    jmp pr_str
+zendproc
+
+    .data
+
+; Messages
+
+    .global usage_msg
+
+usage_msg:      .ascii "Usage: imu [{/L | /S}]\r\n"
+                .ascii "       imu /M <drive> [/O]\r\n"
+                .ascii "       imu /U <drive>\r\n"
+                .ascii "       imu {/N | /D} <image>\r\n"
+                .ascii "       imu {/C | /R} <src image> <dst image>\r\n\r\n"
+                .byte 0
+
+firmware_msg:   .ascii "Error: '/"
+firmware_opt:   .byte 0
+                .ascii "' unsupported.\r\n"
+firmware_msg2:  .ascii "Please upgrade the SD Shield firmware to version >= 2.0\r\n"
+                .byte 0
+
+imagerr_msg:    .ascii "Image name must be in 8.3 format.\r\n"
+                .byte 0
+
+disabled_msg:   .ascii "Disabled by hardware. Please flip option switch 2.\r\n"
+                .byte 0
+
+config_msg:     .ascii "Can't update the SD config file.\r\n"
+                .byte 0
+
+working_msg:    .ascii "On it. May take a while...\r\n"
+                .byte 0

--- a/src/arch/kim-1/utils/imu.S
+++ b/src/arch/kim-1/utils/imu.S
@@ -10,12 +10,10 @@
 
 #include "zif.inc"
 #include "cpm65.inc"
-#include "k-1013.inc"
-
-DMA_BUFFER = $fd00          ; We are using the 256-byte page just below the disk
-DMA_AREA = $f4              ; buffer ($fd00), which encodes to $f4. See K-1013 manual.
 
 ZEROPAGE
+
+    .global string, buffer1, filename1, filename2
 
 string:         .fill 2             ; Pointer for file name operations
 buffer1:        .fill 2             ; Read/Write buffer for disk operations
@@ -26,6 +24,8 @@ filename2:      .fill 2             ; Pointer to 2nd file name
 
 ; Uninitialized program variables
 
+    .global drive, drive_letter, rn_flag
+
 drive:          .fill 1             ; Zero-based drive number
 drive_letter:   .fill 1
 rn_flag:        .fill 1             ; non-zero if a move/rename operation
@@ -34,10 +34,12 @@ rn_flag:        .fill 1             ; non-zero if a move/rename operation
 
 ; Initialized variables
 
+    .global cmdline_index, ro_flag, mn_flag
+
 cmdline_index:  .byte 0
 ro_flag:        .byte 0             ; Read-only flag
 mn_flag:        .byte 0             ; Image mounted flag
-pk_flag:        .byte 0             ; Create packed image flag
+
     .text
 
 ; Program entry point
@@ -222,7 +224,7 @@ zendproc
 ; Copies the image name from the command line into
 ; (buffer1),Y
 ;
-; At exit, Y points to the first position in DMA_BUFFER after
+; At exit, Y points to the first position in buffer1 after
 ; the null character.
 ;
 zproc set_image_name
@@ -375,704 +377,6 @@ zproc mount_drive
 
 zendproc
 
-zproc init
-
-    lda #<DMA_BUFFER
-    sta buffer1+0
-    lda #>DMA_BUFFER
-    sta buffer1+1
-
-    ; Put the disk controller in a sane state
-    ;
-    lda HSRC                        ; Test if an interrupt is pending
-    zif_pl
-        jsr fdc_exec_senseint
-    zendif
-
-    lda #0                          ; Set DMA read mode, unprotect SYSRAM
-    sta HSRC
-
-    ; Using a harmless command to check extended cmds support
-
-    ldy #EXT_CMD_DIR
-    jsr fdc_exec_extended           ; Get SD card directory listing
-    zif_cc
-        ; Dig further for errors
-        lda disk_status
-        zif_pl
-            clc
-            rts
-        zendif
-        lda #<real_msg              ; Extended commands not supported
-        ldx #>real_msg
-    zelse
-        lda #<fdc_msg               ; Controller error
-        ldx #>fdc_msg
-    zendif
-
-    jsr err_withmsg
-    sec
-    rts
-zendproc
-
-; Check if drive exists. Returns C if not.
-;
-zproc drive_exists
-    lda drive
-    cmp #4
-    zif_cs    
-        ldx drive_letter
-        lda #<invalid_msg
-        ldy #>invalid_msg
-        jsr err_withchar
-        sec
-    zendif
-    rts
-zendproc
-
-; Checks that the image name is valid
-; Y must point to the first character of the
-; image name in the command line
-; C set if invalid
-;
-; Just checks that length < 64 chars, excluding
-; terminating null. The firmware does proper
-; validation
-;
-zproc check_valid_file
-
-    ; Find end of file
-
-    dey
-    ldx #0xff
-    zrepeat
-        inx
-        iny
-        lda cpm_cmdline,y
-        zbreakif_mi                 ; Safeguard, stop if len > 128 chars
-    zuntil_eq
-
-    ; Check it isG shorter that 64 chars, fail if not
-
-    cpx #64
-    zif_cs
-        lda #<imagerr_msg           ; Cant be past the 64th pos
-        ldx #>imagerr_msg
-        jsr err_withmsg
-        sec
-    zendif
-    rts
-zendproc
-
-; Produces a list on screen of available images
-; 
-zproc list_mounts
-
-    ldy #EXT_CMD_MNTS
-    jsr fdc_exec_extended           ; Get SD card directory listing
-    zif_cs
-        lda #<fdc_msg
-        ldx #>fdc_msg
-        jmp err_withmsg             ; Controller error
-    zendif
-    
-    ; Set buffer for receiving file names
-
-    lda #DMA_AREA
-    sta ADMA
-
-    zloop
-        ldy #EXT_CMD_NXT_MNT
-        jsr fdc_exec_extended       ; Get SD card directory entry
-        zif_cs
-            lda #<fdc_msg
-            ldx #>fdc_msg
-            jmp err_withmsg         ; Controller error
-        zendif       
-
-        ; Check status for errors
-
-        lda disk_status
-        and #ST4_NO_DATA
-        zbreakif_ne
-
-        jsr print_mount
-
-    zendloop
-    rts
-zendproc
-
-; Produces a list on screen of available images
-; 
-zproc list_images
-
-    ; Set buffer for receiving file names
-
-    lda #DMA_AREA
-    sta ADMA
-
-    zloop
-        ldy #EXT_CMD_NXT
-        jsr fdc_exec_extended       ; Get SD card directory entry
-        zif_cs
-            lda #<fdc_msg
-            ldx #>fdc_msg
-            jmp err_withmsg         ; Controller error
-        zendif       
-
-        ; No need to check for extended command support
-
-        ; Check status for errors
-
-        lda #ST4_NO_DATA
-        bit disk_status
-        ; Testing for ST4_NO_DATA
-        zbreakif_ne
-        ; Testing for ST4_ABNORMAL_TERM (0b0100000)
-        zif_vs
-            lda #<readdir_msg
-            ldx #>readdir_msg
-            jmp err_withmsg         ; Error reading directory
-        zendif
-
-        lda #<DMA_BUFFER           ; Print it
-        ldx #>DMA_BUFFER
-        ldy #BDOS_WRITE_STRING
-        jsr BDOS
-        jsr pr_crlf
-    zendloop
-    rts
-zendproc
-
-; Mount an SD image to a CPM drive
-;
-zproc mount_image
-
-    lda #$01                        ; Set DMA direction bit to write
-    sta HSRC          
-
-    ; Set buffer for sending mount info
-
-    lda #DMA_AREA
-    sta ADMA
-
-    lda ro_flag
-    sta DMA_BUFFER+1
-    lda drive
-    sta DMA_BUFFER+0
-    ora #EXT_CMD_MNT
-    tay
-    jsr fdc_exec_extended           ; Mount image
-    zif_cs
-        lda #<fdc_msg
-        ldx #>fdc_msg
-        jmp err_withmsg             ; Controller error
-    zendif
-    
-    ; Dig further for errors
-
-    lda #ST4_NOT_FOUND
-    bit disk_status
-    ; Testing for ST4_NOT_FOUND
-    zif_ne
-        lda filename1+0
-        ldx filename1+1
-        jmp err_notfound
-    zendif
-    zif_vs
-        lda disk_status+1
-        and #ST5_DRV_MOUNTED
-        zif_ne
-            ; Was not mounted
-            ldx drive_letter
-            lda #<mountederr_msg
-            ldy #>mountederr_msg
-            jmp err_withchar
-        zendif
-        lda disk_status+1
-        and #ST5_IMG_MOUNTED
-        zif_ne
-            ; Was not mounted
-            lda filename1+0
-            ldx filename1+1
-            jmp err_imgmounted
-        zendif
-        lda disk_status+1
-        and #ST5_IMG_INVALID
-        zif_ne
-            ; It is not a valid IMD file
-            lda filename1+0
-            ldx filename1+1
-            jmp err_invalidimg
-        zendif
-        ; If we are here, there was an unexpected error
-
-        ldx drive_letter
-        lda #<mounterr_msg
-        ldy #>mounterr_msg
-        jmp err_withchar
-    zendif
-
-    jmp print_mount                 ; Print the mount info
-
-zendproc
-
-; Unmount a drive.
-;
-zproc unmount_drive
-
-    jsr get_drive
-    zif_cs
-        jmp err_usage
-    zendif
-
-    jsr drive_exists
-    zif_cs
-        rts
-    zendif
-
-    lda drive
-    ora #EXT_CMD_UMNT               ; Unmount drive
-    tay
-    jsr fdc_exec_extended 
-    zif_cs
-        lda #<fdc_msg
-        ldx #>fdc_msg
-        jmp err_withmsg             ; Controller error
-    zendif
-    
-    ; Dig further for errors
-
-    and #ST4_ABNORMAL_TERM
-    zif_ne
-        lda disk_status+1
-        and #ST5_DRV_NOT_MOUNTED
-        zif_ne
-            ; Was not mounted
-            ldx drive_letter
-            lda #<notmntederr_msg
-            ldy #>notmntederr_msg
-            jmp err_withchar
-        zendif
-
-        ; If we are here, there was an unexpected error
-
-        ldx drive_letter
-        lda #<unmnterr_msg
-        ldy #>unmnterr_msg
-        jmp err_withchar
-    zendif
-
-    jmp inf_done
-zendproc
-
-; Update config to flash. Not yet supported
-;
-zproc save_config
-    lda #<unknown_msg
-    ldy #>unknown_msg
-    jsr err_withchar
-    jmp err_usage
-zendproc
-
-
-; Create an empty image on the SD card.
-;
-zproc create_image
-
-    jsr validate_image_name
-    zif_cs
-        rts
-    zendif
-    
-    ; Set filename1
-    ;
-    ; NOTE: We can do this because DMA_BUFFER is page aligned!
-    ;
-    ldy #4                          ; Skip image parameters
-    lda #>DMA_BUFFER
-    sty filename1+0
-    sta filename1+1
-
-    jsr set_image_name              ; Copy image name at DMA_BUFFER,Y
-                                    ; On exit, Y points to the next char after
-                                    ; image name in command line
-    jsr skip_sp
- 
-    cmp #0                          ; End of command line?
-    zif_ne
-        jsr get_option              ; No, get option
-        zif_cs
-            jmp err_usage           ; Syntax error
-        zendif
-        cpx #'P'                    ; Create packaged image
-        zif_eq
-            ldx #PACKAGED_IMG
-            stx pk_flag
-        zelse
-            lda #<unknown_msg
-            ldy #>unknown_msg
-            jsr err_withchar        ; No other switches are supported
-            jmp err_usage
-        zendif
-    zendif    
-
-    jsr skip_sp
-
-    cmp #0
-    zif_ne
-        jmp err_usage               ; Nothing else expected
-    zendif
-
-    lda #$01                        ; Set DMA direction bit to write
-    sta HSRC          
-
-    ; Set buffer for sending mount info
-
-    lda #DMA_AREA
-    sta ADMA
-
-    ; Prepare the command data
-
-    lda #77                         ; Tracks
-    sta DMA_BUFFER+0
-    lda #26                         ; Sectors
-    sta DMA_BUFFER+1
-    lda #1                          ; Sector size ( 1 == 256bytes )
-    ora pk_flag                     ; Whether or not is a packaged image
-    sta DMA_BUFFER+2
-    lda #0xe5                       ; Filler byte
-    sta DMA_BUFFER+3
-    ldy #EXT_CMD_NEW                ; Create image
-    jsr fdc_exec_extended
-    zif_cs
-        lda #<fdc_msg
-        ldx #>fdc_msg
-        jmp err_withmsg             ; Controller error
-    zendif
-    
-    ; Dig further for errors
-
-    lda disk_status
-    and #ST4_ABNORMAL_TERM
-    zif_ne
-        lda #ST5_IMG_NAME
-        bit disk_status+1
-        ; Testing for ST5_IMG_NAME
-        zif_ne
-            lda #<imagerr_msg
-            ldx #>imagerr_msg
-            jmp err_withmsg
-        zendif
-        ; Testing for ST5_DISK_FULL (0b10000000)
-        zif_mi
-            lda #<diskfull_msg
-            ldx #>diskfull_msg
-            jmp err_withmsg
-        zendif
-        ; Testing for ST5_IMG_EXISTS ( 0b0100000)
-        zif_vs
-            lda #<exists_msg
-            ldx #>exists_msg
-            jmp err_withmsg
-        zendif
-        ; If we are here, there was an unexpected error
-        lda #<generic_msg
-        ldy #>generic_msg
-        jmp err_withmsg
-    zendif
-
-    jmp inf_done
-zendproc
-
-; Delete file on the SD card
-;
-zproc delete_file
-    jsr set_first_image_name
-    zif_cs
-        rts
-    zendif
-
-    cmp #0
-    zif_ne
-        jmp err_usage               ; Nothing else expected
-    zendif
-
-    lda #$01                        ; Set DMA direction bit to write
-    sta HSRC          
-
-    ; Set buffer for sending mount info
-
-    lda #DMA_AREA
-    sta ADMA
-
-    ; Prepare the command data
-
-    ldy #EXT_CMD_ERA                ; Delete image
-    jsr fdc_exec_extended
-    zif_cs
-        lda #<fdc_msg
-        ldx #>fdc_msg
-        jmp err_withmsg             ; Controller error
-    zendif
-    
-    ; Dig further for errors
-
-    lda #ST4_NOT_FOUND
-    bit disk_status
-    ; Testing for ST4_NOT_FOUND
-    zif_ne
-        lda filename1+0
-        ldx filename1+1
-        jmp err_notfound
-    zendif
-    ; Testing for ST4_ABNORMAL_TERM (0b01000000)
-    zif_vs
-        lda disk_status+1
-        and #ST5_IMG_NAME
-        zif_ne
-            ; Invalid image name
-            lda #<imagerr_msg
-            ldx #>imagerr_msg
-            jmp err_withmsg
-        zendif
-        lda disk_status+1
-        and #ST5_IMG_MOUNTED
-        zif_ne
-            ; Was not mounted
-            lda filename1+0
-            ldx filename1+1
-            jmp err_imgmounted
-        zendif
-        ; If we are here, there was an unexpected error
-        lda #<generic_msg
-        ldy #>generic_msg
-        jmp err_withmsg
-    zendif
-
-    jmp inf_done
-zendproc
-
-; Copy or rename src file to dst file on the SD card
-;
-zproc copy_or_move_file
-    jsr set_first_image_name
-    zif_cs
-        rts
-    zendif
-
-    ; Set second file name into buffer
-
-    jsr set_second_image_name
-    zif_cs
-        rts
-    zendif
-
-    cmp #0
-    zif_ne
-        jmp err_usage               ; Nothing else expected
-    zendif
-
-    lda #$01                        ; Set DMA direction bit to write
-    sta HSRC          
-
-    ; Set buffer for sending mount info
-
-    lda #DMA_AREA
-    sta ADMA
-
-    ; Prepare the command data
-
-    lda rn_flag
-    zif_ne
-        ldy #EXT_CMD_MOV            ; Move/rename image
-    zelse
-        ldy #EXT_CMD_CPY            ; Copy image
-    zendif
-
-    jsr fdc_exec_extended
-    zif_cs
-        lda #<fdc_msg
-        ldx #>fdc_msg
-        jmp err_withmsg             ; Controller error
-    zendif
-    
-    ; Dig further for errors
-
-    lda #ST4_NOT_FOUND
-    bit disk_status
-    ; Testing for ST4_NOT_FOUND
-    zif_ne
-        lda filename1+0
-        ldx filename1+1
-        jmp err_notfound
-    zendif
-    ; Testing for ST4_ABNORMAL_TERM (0b01000000)
-    zif_vs
-        lda #ST5_IMG_NAME
-        bit disk_status+1
-        ; Testing for ST5_IMG_NAME
-        zif_ne
-            lda #<imagerr_msg
-            ldx #>imagerr_msg
-            jmp err_withmsg
-        zendif
-        ; Testing for ST5_DISK_FULL (0b10000000)
-        zif_mi
-            lda #<diskfull_msg
-            ldx #>diskfull_msg
-            jmp err_withmsg
-        zendif
-        ; Testing for ST5_IMG_EXISTS ( 0b0100000)
-        zif_vs
-            lda #<exists_msg
-            ldx #>exists_msg
-            jmp err_withmsg
-        zendif
-        lda disk_status+1
-        and #ST5_IMG_MOUNTED
-        zif_ne
-            ; Was not mounted
-            lda filename1+0
-            ldx filename1+1
-            jmp err_imgmounted
-        zendif
-        lda disk_status+1
-        and #ST5_IMG2_MOUNTED
-        zif_ne
-            ; Was not mounted
-            lda filename2+0
-            ldx filename2+1
-            jmp err_imgmounted
-        zendif
-        ; If we are here, there was an unexpected error
-        lda #<generic_msg
-        ldy #>generic_msg
-        jmp err_withmsg
-    zendif
-
-    jmp inf_done
-zendproc
-
-; Execute extended command
-; Command number in Y
-
-zproc fdc_exec_extended
-
-    sty fdc_extended+2              ; Set command number 
-
-    ldx #fdc_extended-fdc_commands  ; Command index into X
-    jsr fdc_exec_command
-    zif_cc
-        zrepeat
-            lda HSRC                ; Wait for interrupt
-        zuntil_pl
-    zendif
-    ; Read results into memory even if it failed (should be
-    ; unsupported command)
-    ;
-    jsr fdc_read_result
-    rts
-zendproc
-
-zproc fdc_exec_senseint
-    ; Wait until FDC interrupt
-
-    zrepeat
-        lda HSRC
-    zuntil_pl
-
-    ; Execute Sense Interrupt command
-
-    ldx #fdc_senseint-fdc_commands
-    jsr fdc_exec_command
-    zif_cc
-        ; Read results into memory
-
-        jsr fdc_read_result
-        zif_cc
-
-            ; Look for error in the status registers
-
-            lda disk_status         ; Check ST0
-            and #0xf8               ; Delete don't care bits
-            cmp #0x20               ; Result must be "Seek Completed"
-            bne fdc_fail
-            clc
-        zendif
-    zendif
-    rts
-zendproc
-
-zproc fdc_fail
-    sec
-    rts
-zendproc
-
-zproc fdc_exec_command
-
-    lda MSTR                        ; Load Main Status Register
-    and #0x10                       ; Check if busy
-    bne fdc_fail
-
-    ldy fdc_commands, x             ; Load command length
-    inx
-
-    zloop
-        zrepeat
-            lda MSTR                ; Wait until RQM from controller
-        zuntil_mi
-        and #0x40                   ; Test data direction bit
-        bne fdc_fail                ; Error if controller wants to talk
-
-        lda fdc_commands, x         ; Get command byte
-        sta DATR                    ; Store into FDC data register
-        inx                         ; Next command byte
-        dey
-    zuntil_eq
-
-    clc
-    rts
-zendproc
-
-zproc fdc_read_result
-    ldx #0
-    zloop
-        zrepeat
-            lda MSTR                ; Wait until RQM from controller
-        zuntil_mi
-        and #0x40                   ; Test data direction bit
-        beq fdc_fail                ; Error if controller wants to listen
-
-        lda DATR                    ; Get status byte from data register
-        sta disk_status, x          ; Put it into memory
-        inx                         ; Next byte
-        nop                         ; Give the controller time to update
-        nop                         ; the MSTR with a valid busy status
-        lda #0x10                   ; Check if busy and go get another
-        and MSTR                    ; byte while so
-    zuntil_eq
-
-    clc
-    rts
-zendproc
-
-; Error/Info message routines
-;
-zproc err_invalidimg
-    sta string+0
-    stx string+1
-    lda #<invalidimg_msg
-    ldx #>invalidimg_msg
-    jsr pr_str
-    lda string+0
-    ldx string+1
-    jsr pr_str
-    lda #<invalidimg_msg2
-    ldx #>invalidimg_msg2
-    jmp pr_str
-zendproc
-
 zproc pr_str
     ldy #BDOS_WRITE_STRING
     jmp BDOS
@@ -1173,53 +477,10 @@ zendproc
 
     .data
 
-; FDC extended command
-
-fdc_commands:
-
-fdc_senseint:
-    .byte 1                         ; Command length
-    .byte 8                         ; Sense Interrupt Status
-
-fdc_extended:
-    .byte 2                         ; Command length
-    .byte 0x1f                      ; Extended command
-    .byte 0                         ; Command number
-
-disk_status:    .fill 8             ; Result phase readouts from NEC-765
-
 ; Messages
 
-usage_msg:      .ascii "Usage: imu [/L]\n\r"
-                .ascii "       imu /M <drive> <image>[/O]\n\r"
-                .ascii "       imu /U <drive>\n\r"
-                .ascii "       imu /N <image> [/P]\n\r"
-                .ascii "       imu /D <image>\n\r"
-                .ascii "       imu {/C | /R} <src image> <dst image>\n\r\n\r"
-                .byte 0
-
-fdc_msg:        .ascii "Unexpected floppy controller failure.\n\r"
-                .byte 0
-
-real_msg:       .ascii "Not supported. Old firmware or real hardware.\n\r"
-                .byte 0
-
-diskfull_msg:   .ascii "SD card is full!\n\r"
-                .byte 0
-
-imagerr_msg:    .ascii "Image name invalid or longer than 63 chars.\n\r"
-                .byte 0
-
-open_msg:       .ascii "Failed to open directory.\n\r"
-                .byte 0
-
-readdir_msg:    .ascii "Failed to read directory.\n\r"
-                .byte 0
-
-invalidimg_msg: .ascii "Error: File '"
-                .byte 0
-invalidimg_msg2:.ascii "' is not a valid IMD image.\n\r"
-                .byte 0
+    .global unknown_msg, invalid_msg, mounterr_msg, mountederr_msg
+    .global unmnterr_msg, notmntederr_msg, generic_msg, exists_msg
 
 error_msg:      .ascii "Error: "
                 .byte 0
@@ -1251,34 +512,34 @@ mount_msg:      .byte 0
                 .ascii ": -> "
                 .byte 0
 
-ro_msg:         .ascii "  (RO)\n\r"
+ro_msg:         .ascii "  (RO)\r\n"
                 .byte 0
 
 notfound_msg:   .ascii "Error: File '"
                 .byte 0
-notfound2_msg:  .ascii "' not found.\n\r"
+notfound2_msg:  .ascii "' not found.\r\n"
                 .byte 0
 
-generic_msg:    .ascii "Can't complete operation.\n\r"
+generic_msg:    .ascii "Can't complete operation.\r\n"
                 .byte 0
                 
-exists_msg:     .ascii "File already exists.\n\r"
+exists_msg:     .ascii "File already exists.\r\n"
                 .byte 0
 
 imgmounted_msg: .ascii "Error: Image file '"
                 .byte 0
-imgmounted_msg2:.ascii "' already mounted.\n\r"
+imgmounted_msg2:.ascii "' already mounted.\r\n"
                 .byte 0
 
 warning_msg:    .ascii "Warning: About to delete file '"
                 .byte 0
-warning_msg2:   .ascii "'.\n"
+warning_msg2:   .ascii "'.\r\n"
                 .ascii "Press Y to proceed, anything else to cancel: "
                 .byte 0
 
 abort_msg:      .byte 13,10
-                .ascii "Aborted by user.\n\r"
+                .ascii "Aborted by user.\r\n"
                 .byte 10
 
-done_msg:       .ascii "Done.\n\r"
+done_msg:       .ascii "Done.\r\n"
                 .byte 0

--- a/src/arch/kim-1/utils/sdshield.S
+++ b/src/arch/kim-1/utils/sdshield.S
@@ -1,0 +1,515 @@
+;=====================================================
+; This is a collection of functions for performing
+; higher level disk functions.  This hides the nasty
+; details of communications with the remote disk
+; system.
+;
+; August 20, 2014 - Bob Applegate
+;                   bob@corshamtech.com
+;
+; 06/14/2015 - Bob Applegate
+;       Now that there is an official standard
+;       for the protocol between the host (this
+;       code) and the DCP (Arduino code), this
+;       code has been updated to be compliant.
+;
+; 01/13/2025 - Eduardo Casino
+;       Adapted some functions to the 6502.
+;       Implemented DiskFormat, GetVersion, GetProtocol,
+;       DiskErase, DiskCopy, DiskRename
+;       Fixed error return for read/write
+;
+
+#include "zif.inc"
+#include "parproto.inc"
+
+.section .zp, "zax", @nobits
+
+.global zp_sds_dpb, zp_sds_drive, zp_sds_track, zp_sds_sector
+.global zp_sds_spt, zp_sds_buffer
+
+; Disk parameter block
+
+zp_sds_dpb:
+zp_sds_drive:           .fill 1
+zp_sds_track:           .fill 1
+zp_sds_sector:          .fill 1
+zp_sds_spt:             .fill 1     ; Sectors per track
+zp_sds_buffer:          .fill 2     ; Pointer to data buffer
+
+;=====================================================
+; Unmount a filesystem.  On entry, A contains the
+; zero-based drive number.
+;
+; Returns with C clear on success.  If error, C is set
+; and A contains the error code.
+;
+zproc DiskUnmount, .text.DiskUnmount
+    pha                     ;save drive
+    lda #PC_UNMOUNT
+    jsr xParWriteByte
+    pla
+    jsr xParWriteByte
+zendproc
+; Fall through
+;
+; Handy entry point.  This sets the mode to read, gets
+; an ACK or NAK, and if a NAK, gets the error code
+; and returns it in A.
+;
+zproc ComExit, .text.ComExit
+    jsr xParSetRead         ;get ready for response
+    jsr xParReadByte
+    cmp #PR_ACK
+    beq DiskCsuccess
+zendproc
+; Fall through
+zproc DiskRetErrCode, .text.DiskRetErrCode
+    ;
+    ; Assume it's a NAK.
+    ;
+    jsr xParReadByte        ;get error code
+    pha
+    jsr xParSetWrite
+    pla
+    sec
+    rts
+zendproc
+
+zproc DiskCerror, .text.DiskCerror
+    jsr xParSetWrite
+    sec
+    rts
+zendproc
+
+zproc DiskCsuccess, .text.DiskCsuccess
+    jsr xParSetWrite
+    clc
+    rts
+zendproc
+
+;=====================================================
+; Mount a filesystem.  On entry, A contains a zero
+; based drive number, X is the read-only flag (0 or
+; non-zero), and zp_sds_buffer points to a filename to
+; mount on that drive.  
+;
+; Returns with C clear on success.  If error, C is set
+; and A contains the error code.
+;
+zproc DiskMount, .text.DiskMount
+    pha                     ;save drive
+    lda #PC_MOUNT
+    jsr xParWriteByte       ;send the command
+    pla
+    jsr xParWriteByte       ;send drive number
+    txa
+    jsr xParWriteByte       ;send read-only flag
+    ;
+    ; Now send each byte of the filename until the end,
+    ; which is a 0 byte.
+    ;
+    ldy #0
+    zrepeat
+        lda (zp_sds_buffer),y
+        pha
+        jsr xParWriteByte
+        iny
+        pla
+    zuntil_eq
+    jmp ComExit
+zendproc
+
+;=====================================================
+; remove a file from the SD.  On entry, zp_sds_buffer
+; points to a null-terminated file name
+;
+; Returns with C clear on success.  If error, C is set
+; and A contains the error code.
+;
+zproc DiskErase, .text.DiskErase
+    lda #PC_ERASE
+    jsr xParWriteByte       ;send the command
+    ;
+    ; Now send the filename
+    ;
+    ldy #0
+    jsr SendString
+    jmp ComExit
+zendproc
+
+; Sends string to the SD shield
+; Y = Start of string in buffer
+; On exit, Y points to the first byte after the
+; terminating null, so it can be chained
+;
+zproc SendString, .text.SendString
+    zrepeat
+        lda (zp_sds_buffer),y
+        pha
+        jsr xParWriteByte
+        iny
+        pla
+    zuntil_eq
+    rts
+zendproc
+
+;=====================================================
+; Copy a file on the SD.  On entry, zp_sds_buffer
+; points to a succession of two null-terminated file
+; names
+;
+; Returns with C clear on success.  If error, C is set
+; and A contains the error code.
+;
+zproc DiskCopy, .text.DiskCopy
+    lda #PC_COPY
+    jsr xParWriteByte       ;send the command
+
+    ;
+    ; Now send each byte of both filenames
+    ;
+    ldy #0
+    jsr SendString
+    jsr SendString
+    jmp ComExit
+zendproc
+
+;=====================================================
+; Rename a file on the SD.  On entry, zp_sds_buffer
+; points to a succession of two null-terminated file
+; names
+;
+; Returns with C clear on success.  If error, C is set
+; and A contains the error code.
+;
+zproc DiskRename, .text.DiskRename
+    lda #PC_RENAME
+    jsr xParWriteByte       ;send the command
+
+    ;
+    ; Now send each byte of both filenames
+    ;
+    ldy #0
+    jsr SendString
+    jsr SendString
+    jmp ComExit
+zendproc
+
+;=====================================================
+; This starts a directory read of the raw drive, not
+; the mounted drive.  No input parameters.  This simply
+; sets up for reading the entries, then the user must
+; read each entry.
+;
+; Returns with C clear on success.  If error, C is set
+; and A contains the error code.
+;
+zproc DiskDir, .text.DiskDir
+    lda #PC_GET_DIR         ;send command
+    jmp xParWriteByte
+    clc                     ;assume it works
+    rts
+zendproc
+
+;=====================================================
+; Read the next directory entry.  On input, zp_sds_buffer
+; points to a 13 byte area to receive the drive data.
+;
+; Returns C set if end of directory (ie, attempt to
+; read and there are none left).  Else, C is clear
+; and zp_sds_buffer point to the null at end of filename.
+;
+zproc DiskDirNext, .text.DiskDirNext
+    jsr xParSetRead         ;read results
+    jsr xParReadByte        ;get response code
+    cmp #PR_NAK             ;error?
+    beq DiskRetErrCode
+    cmp #PR_DIR_END         ;end?
+    ;
+    ; Error.  Set C and return.  This is not really
+    ; proper, since this implies a simple end of the
+    ; directory rather than an error.
+    ;
+    beq DiskCerror
+    ;
+    ; This contains a directory entry.
+    ;
+    ldy #0
+    zloop
+        jsr xParReadByte
+        sta (zp_sds_buffer),y
+        zbreakif_eq
+        inc zp_sds_buffer
+        zcontinueif_ne
+        inc zp_sds_buffer+1
+    zendloop
+        jmp DiskCsuccess     
+zendproc
+
+;=====================================================
+; Get list of mounted drives.  This starts the
+; process, then each call to DiskNextMountedDrv will
+; return the next drive in sequence.
+;
+zproc DiskGetMounted, .text.DiskGetMounted
+    lda #PC_GET_MOUNTED     ;start command
+    jmp xParWriteByte
+zendproc
+
+;=====================================================
+; Get next mounted drive.  On entry, zp_sds_buffer points
+; to a XXX byte area to receive the data.  Each call
+; loads the area with:
+;
+; Drive number - 1 byte
+; Read-only flag.  0 = read/write, non-zero = read-only
+; File name    - X bytes of filename (xxxxxxxx.xxx)
+; null         - 1 byte ($00)
+;
+; If C is clear, then the data area is populated with
+; data.  If C is set, then there are no more entries.
+;
+zproc DiskNextMountedDrv, .text.DiskNextMountedDrv
+    jsr xParSetRead
+    jsr xParReadByte
+    cmp #PR_DIR_END         ;end?
+    zif_eq
+        jmp DiskCerror
+    zendif
+    cmp #PR_NAK             ;NAK?
+    zif_eq
+        jmp DiskRetErrCode
+    zendif
+;
+; Get drive number, then read-only flag
+;
+    jsr xParReadByte        ;drive
+    ldy #0
+    sta (zp_sds_buffer),y
+    iny
+    jsr xParReadByte        ;read-only flag
+    sta (zp_sds_buffer),y
+    zrepeat
+        iny
+        jsr xParReadByte
+        sta (zp_sds_buffer),y
+    zuntil_eq
+    jmp DiskCsuccess
+zendproc
+
+;=====================================================
+; Gets status of a specific drive.  The drive number
+; (0-3) is in A on entry.
+;
+; Returns a bitmapped value in A:
+;
+;    P0000ERU
+;
+;  U: 0 = not present, 1 = Mounted
+;  R: 0 = Read only, 1 = Read/write
+;  E: 0 = no error, 1 = access error (bad sector?)
+;
+; The E bit will never be set for status.
+;
+zproc DiskStatus, .text.DiskStatus
+    pha
+    lda #PC_GET_STATUS      ;get status command
+    jsr xParWriteByte       ;send request for data
+    pla
+    jsr xParWriteByte
+    jsr xParSetRead
+    jsr xParReadByte        ;get result code
+    cmp #PR_STATUS          ;status
+    zif_ne
+        jmp DiskCerror      ;can't be anything else
+    zendif
+    jsr xParReadByte
+zendproc
+; Fall through
+zproc DiskRetSt, .text.DiskRetSt
+    pha
+    jsr xParSetWrite
+    pla
+    clc
+    rts
+zendproc
+
+;=====================================================
+; This opens a file on the SD for writing.  On entry,
+; zp_sds_buffer points to a null-terminated
+; filename to open.  On return, C is clear if the file
+; is open, or C set if an error.
+;
+; Assumes write mode has been set.  Returns with it set.
+;
+zproc DiskOpenWrite, .text.DiskOpenWrite
+    lda #PC_WRITE_FILE
+zendproc
+zproc DiskOpen, .text.DiskOpen
+    jsr xParWriteByte
+    ldy #0xff
+    zrepeat
+        iny
+        lda (zp_sds_buffer),y
+        pha
+        jsr xParWriteByte
+        pla
+    zuntil_eq
+    jmp ComExit
+zendproc
+
+;=====================================================
+; On entry, A contains the number of bytes to write
+; to the file, zp_sds_buffer points to the
+; buffer where to get the data.  On return, C will
+; be set if an error was detected, or C will be clear
+; if no error.  Note that if A contains 0 on entry,
+; no bytes are written.
+;
+; 
+; Modifies A, X and Y.
+;
+zproc DiskWrite, .text.DiskWrite
+    zif_eq
+        clc
+        rts
+    zendif
+    pha                     ; Save number of bytes to write
+    lda #PC_WRITE_BYTES
+    jsr xParWriteByte       ;command
+    pla                     ;number of bytes to write
+    pha                     ;save again
+    jsr xParWriteByte
+    pla
+    tax                     ;count
+    ldy #0                  ;offset
+    zrepeat
+        lda (zp_sds_buffer),y ;get next byte
+        jsr xParWriteByte
+        iny                 ;next offset
+        dex
+    zuntil_eq
+    jmp ComExit
+zendproc
+
+;=====================================================
+; Call this to close any open file.  No parameters
+; and no return status.
+;
+zproc DiskClose, .text.DiskClose
+    lda #PC_DONE
+    jmp xParWriteByte
+zendproc
+
+;=====================================================
+; This formats a drive.  On entry, zp_sds_dpb is a disk
+; parameter block with the following data fields:
+;
+;                      DS   1   ;unused
+;    number of tracks  DS   1
+;    number of sectors DS   1   ;sectors per track
+;    sector fill value DS   1
+;    ptr to filename   DS   2
+;
+; If the number of tracks or number of sectors is
+; zero, then that indicates a value of 256.
+;
+; This only creates an empty file of the appropriate
+; size; it does not initialize any data structures.
+;
+zproc DiskFormat, .text.DiskFormat
+    lda #PC_FORMAT          ;format sector command
+    jsr xParWriteByte
+    lda zp_sds_track        ;get number of tracks
+    jsr xParWriteByte
+    lda zp_sds_sector       ;get sectors per track (beware the fields in
+    jsr xParWriteByte       ;this file parameter block have different meaning!)
+    lda zp_sds_spt          ;get filler byte
+    jsr xParWriteByte
+    ldy #0xff               ;get null-terminated file name
+    zrepeat             
+        iny
+        lda (zp_sds_buffer),y
+        pha
+        jsr xParWriteByte
+        pla
+    zuntil_eq
+    jmp ComExit
+zendproc
+
+;=====================================================
+; Gets protocol version information from the SD Shield.
+;
+; Returns C clear and proto version in A on success,
+; C set if failure
+;
+zproc GetProtoVersion .text.GetProtoVersion
+    lda #PR_VERSION_INFO    ; Get protocol version information
+    jsr xParWriteByte
+;
+; Now get response.
+;
+    jsr xParSetRead
+    jsr xParReadByte
+    cmp #PR_VERSION_INFO
+    zif_eq
+        jsr xParReadByte    ; Get protocol version
+        jmp DiskRetSt       ; Return preserving A
+    zendif
+    jmp DiskCerror          ; Should not happen
+
+;=====================================================
+; Gets version information from the SD Shield.
+;
+; WARNING: Works with protocol version 2
+;
+; Returns C clear and major/minor in XA on success,
+; C set if failure
+;
+zproc GetVersion, .text.GetVersion
+    lda #PC_GET_VERSION     ; Get version information
+    jsr xParWriteByte
+;
+; Now get response.
+;
+    jsr xParSetRead
+    jsr xParReadByte
+    cmp #PR_VERSION_INFO
+    zif_eq
+        jsr xParReadByte    ; Get major
+        tax
+        jsr xParReadByte    ; Get minor
+        jmp DiskRetSt       ; Return preserving A
+    zendif
+    jmp DiskCerror
+zendproc
+
+;=====================================================
+; Save current configuration in the SD card config file
+;
+; Returns with C clear on success.  If error, C is set
+; and A contains the error code.
+;
+zproc SaveConfig, .text.SaveConfig
+    lda #PC_SAVE_CONFIG
+    jsr xParWriteByte       ;send the command
+    jmp ComExit
+zendproc
+
+;=====================================================
+; Get the maximum number of drives supported.  This
+; takes no input parameters.  Returns a value in A
+; that is the number of drives supported.  This is a
+; one based value, so a return of 4 indicates that four
+; drives are supported, 0 to 3.
+;
+; NOTE: Eduardo: May implement the real function in the
+;       future. Now, just return 4, which are the drives
+;       supported by current firmware
+;
+zproc DiskGetDrives, .text.DiskGetDrives
+    lda	#4
+    clc
+	rts
+zendproc


### PR DESCRIPTION
Hi, this is a new variant of the KIM-1 port, which uses Corsham's SD Shield (either the original, [a clone like this one](https://github.com/eduardocasino/sd-card-shield) or even this [Raspberry Pi Pico based variant](https://retro-spy.com/product/sd-card-system/)) to emulate up to 4 disks.

Also includes `IMU.COM`, an Image Manipulation Utility, that allows mounting and unmounting disk images and, [with the latest SD Shield firmware](https://github.com/eduardocasino/SD-drive/tree/version-2), even copy, rename, delete or create new ones. 