### PR TITLE
osi: img2osi, initialize local parity variable with 0

### DIFF
--- a/tools/img2osi.c
+++ b/tools/img2osi.c
@@ -62,7 +62,7 @@ static void put_bit(bool bit) {
 }
 
 static void put_byte_8E1(uint8_t byte) {
-    bool parity;
+    bool parity = 0;
     put_bit(0);                 // start bit
     for (int i=0; i<8; i++) {
         bool bit = byte & (1<<i);


### PR DESCRIPTION
Somehow this has not resulted in bad images on github yet, but locally I stumbled upon parity errors. This fixes that.

Regards,
Ivo
