### PR TITLE
Updates to z65

### DIFF
--- a/third_party/z65/build.py
+++ b/third_party/z65/build.py
@@ -4,7 +4,7 @@ from tools.build import unixtocpm
 
 llvmprogram(
     name="z65",
-    cflags=["-Ithird_party/zmalloc"],
+    cflags=["-Ithird_party/zmalloc -DDEBUG=0 -DSTATUS=1"],
     srcs=["./z65.c"],
     deps=["lib+cpm65", "third_party/zmalloc+zmalloc"],
 )

--- a/third_party/z65/z65.c
+++ b/third_party/z65/z65.c
@@ -74,6 +74,7 @@
 #define OP0_POP 0x09
 #define OP0_QUIT 0x0A
 #define OP0_NEW_LINE 0x0B
+#define OP0_SHOW_STATUS 0x0C
 #define OP0_VERIFY 0x0D
 
 // VAR
@@ -1532,7 +1533,11 @@ static void step(void)
 			case OP0_NEW_LINE:
 				crlf();
 				break;
-
+            case OP0_SHOW_STATUS:
+#if STATUS
+                update_status();
+#endif
+                break;
 			case OP0_QUIT:
 				cpm_warmboot();
 				break;

--- a/third_party/z65/z65.c
+++ b/third_party/z65/z65.c
@@ -128,8 +128,7 @@
  */
 
 #define PAGE_SIZE 512
-#define NUM_PAGES 2
-#define DYNAMIC_MEM_MAX 12000
+#define NUM_PAGES 8
 
 #define STACK_SIZE 512
 #define MAX_FRAMES 16

--- a/third_party/z65/z65.c
+++ b/third_party/z65/z65.c
@@ -928,7 +928,7 @@ uint8_t save_game(void)
 				enc++;
 			} else {
 				zero_cnt++;
-				if (zero_cnt == 0x80) {
+				if (zero_cnt == 0xff) {
 					write_zero_block(&saveFile, writeSector, zero_cnt);
 					enc += zero_cnt;
 					zero_cnt = 0;


### PR DESCRIPTION
After actually playing a few games I made some updates:
* A couple of missing opcodes have been added
* The status bar was added as it is important in some games (it can be removed by build flags)
* The number of cached paged was increased to improve performance (makes a big difference on systems with slow disk access)
* File saving compression can store maximum 0xFF on unchanged run length instead of 0x80

I have played through Moonglow (it's not very long...) on the Atari 800, the Oric and the BBC Micro and it is completely playable with the increased number of cached pages. Before it was a bit too sluggish at times.